### PR TITLE
Updates to enable launch of EC2 instances via user-defined templates

### DIFF
--- a/conf/muchos.props.example
+++ b/conf/muchos.props.example
@@ -57,6 +57,9 @@ java_package=java-1.8.0-openjdk-devel
 # Before using this AMI, subscribe to it on the CentOS product page below or launching will fail:
 #   https://aws.amazon.com/marketplace/pp/B00O7WM7QW
 aws_ami = ami-9887c6e7
+# Select a template from conf/templates to leverage user-defined instance types (optional)
+# See conf/templates/README.md for instructions
+#cluster_template = example
 # Type of AWS instance launched by default
 default_instance_type = m5d.large
 # Type of AWS instance launched for any node running 'worker' service

--- a/conf/templates/.gitignore
+++ b/conf/templates/.gitignore
@@ -1,0 +1,5 @@
+*
+!.gitignore
+!README.md
+!example/*.json
+!example/.devices

--- a/conf/templates/README.md
+++ b/conf/templates/README.md
@@ -1,0 +1,188 @@
+## Muchos EC2 Cluster Templates
+
+Cluster templates are intended to provide greater flexibility, if needed,
+with respect to instance type selection and launch configuration for
+your EC2 hosts. For example, cluster templates may be ideal for uses
+cases that require distinct, per-host launch configurations, and
+for use cases that require hosts to have persistent, EBS-backed data
+volumes (rather than ephemeral volumes, the muchos default for EC2
+clusters)
+
+If you are already familiar with muchos and with the basics of EC2
+launch requests, then creating your own launch templates will be simple
+and straightforward.
+
+Please follow the guidance provided here to ensure compatibility between
+your custom templates and muchos automation
+
+## Configuration
+
+### Select a cluster template in *muchos.props*
+```
+[ec2]
+...
+cluster_template = example
+...
+```
+The configured value must match the name of a subdirectory under
+`conf/templates`
+
+```
+~$ ls -1a fluo-muchos/conf/templates/example
+.
+..
+.devices
+metrics.json
+namenode.json
+resourcemanager.json
+zookeeper.json
+worker.json
+```
+The subdirectory will contain one or more user-defined EC2 launch
+templates (*\*.json*) for your various host types, and it will
+include a *.devices* file specifying the desired mount points for all
+data volumes (excluding root volumes, as they are mounted
+automatically)
+
+### Defining EC2 launch templates and device mounts for your hosts
+
+#### Launch Templates: *{service-name}.json*
+
+Each JSON file represents a standard EC2 launch request, and each file
+name must match one of the predefined muchos service names, as
+defined in the **nodes** section of *muchos.props*. E.g.,
+```
+... 
+[nodes]
+leader1 = namenode,resourcemanager,accumulomaster
+leader2 = metrics,zookeeper
+worker1 = worker
+worker2 = worker
+worker3 = worker
+worker4 = worker
+```
+In template mode, the first service listed for a given host denotes the
+template to be selected for its launch.
+
+Based on the example given above:
+* **leader1** selects **namenode.json**
+* **leader2** selects **metrics.json**
+* **worker1** selects **worker.json**
+* and so on...
+  
+For example, *namenode.json* might be defined as follows...
+```
+{
+    "KeyName": "${key_name}",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/sda1",        # Here, /dev/sda1 denotes the root volume
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 40,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdf",          # Here, /dev/sdf (a.k.a "/dev/xvdf") denotes
+            "Ebs": {                           # our single EBS-backed data volume
+                "DeleteOnTermination": true, 
+                "VolumeSize": 500,
+                "VolumeType": "gp2"
+            } 
+        }
+    ], 
+    "ImageId": "${aws_ami}",
+    "InstanceType": "m4.4xlarge",
+    "NetworkInterfaces": [
+        {
+            "DeviceIndex": 0,
+            "AssociatePublicIpAddress": ${associate_public_ip},
+            "Groups": [
+                "${security_group_id}"
+            ]
+        }
+    ],
+    "EbsOptimized": true,
+    "InstanceInitiatedShutdownBehavior": "${shutdown_behavior}"
+}
+```
+*Property Placeholders*
+
+The `${property name}` placeholders demonstrated above are optional and
+are intended to simplify template creation and reduce maintenance burden.
+They allow any matching properties from the **ec2** section of *muchos.props*
+to be interpolated automatically.
+
+If needed, you may also define your own custom properties and have them be injected
+automatically by simply adding them to the **ec2** section of
+*muchos.props* and to your templates
+
+#### Device Mounts: *.devices*
+
+The *.devices* file contains the user-defined mapping of storage
+devices and mount points for all data (i.e., non-root) volumes in your
+cluster.
+
+Two (and only two) device mappings should exist within *.devices*:
+* One map to represent your **worker** device mounts, and
+* One map to represent the device mounts on all other hosts, i.e., the
+  **default** map
+  
+For example, the *.devices* file below specifies 4 mount points for all
+`worker` instance types, and specifies 1 mount point for all
+other hosts via the `default` map.
+```
+{
+   "default": {
+       "mounts": [
+          "/data0"     # For non-workers, mount the /data0 directory
+       ],              # on /dev/xvdf (a.k.a "/dev/sdf")
+       "devices": [
+          "/dev/xvdf"
+       ]
+  },
+  "worker": {
+      "mounts": [
+          "/data0",
+          "/data1",
+          "/data2",
+          "/data3"     # For workers, mount the /data0 directory on 
+      ],               # /dev/xvdf (a.k.a "/dev/sdf"), mount /data1 on
+      "devices": [     # /dev/xvdg (a.k.a "/dev/sdg"), and so on...
+          "/dev/xvdf",
+          "/dev/xvdg",
+          "/dev/xvdh",
+          "/dev/xvdi"
+      ]
+  }
+}
+```
+Naturally, you should take care to ensure that your **BlockDeviceMappings**
+also align to *default* vs *worker* node type semantics. As you
+explore the example files, you should observe the implicit link betweeen
+a data volume denoted by *BlockDeviceMappings\[N].DeviceName* and its
+respective device map entry in the *.devices* file.
+
+* **Note**: While *DeviceName* mount profiles should not vary among
+  your default (non-worker) nodes, other attributes within *BlockDeviceMappings*,
+  such as *DeleteOnTermination*, *VolumeSize*, *etc*, may vary as needed
+
+* **Note**: Be aware that the device names used by AWS EC2 launch requests
+  may differ from the actual names assigned by the EC2 block device driver, which
+  can be confusing. Please read
+  [this](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html)
+  and [also this](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html)
+  for additional information and guidance, if needed
+
+* **Note**: Root EBS volumes may be configured as desired in your JSON
+  launch templates, but only non-root, "data" storage devices should be
+  specified in *.devices*, as root devices are mounted automatically
+  
+    
+## Beyond the Launch Phase: *Setup*, *Terminate*, *Etc*
+
+Aside from the configuration differences described above, which impact
+the `launch` phase, all other muchos operations behave the same in
+template mode as is in default mode
+ 

--- a/conf/templates/example/.devices
+++ b/conf/templates/example/.devices
@@ -1,0 +1,24 @@
+{
+    "default": {
+        "mounts": [
+            "/data0"
+        ],
+        "devices": [
+            "/dev/xvdf"
+        ]
+    },
+    "worker": {
+        "mounts": [
+            "/data0",
+            "/data1",
+            "/data2",
+            "/data3"
+        ],
+        "devices": [
+            "/dev/xvdf",
+            "/dev/xvdg",
+            "/dev/xvdh",
+            "/dev/xvdi"
+        ]
+    }
+}

--- a/conf/templates/example/accumulomaster.json
+++ b/conf/templates/example/accumulomaster.json
@@ -1,0 +1,34 @@
+{
+    "KeyName": "${key_name}",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+                "DeleteOnTermination": true, 
+                "VolumeSize": 40,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdf",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 500,
+                "VolumeType": "gp2"
+            }
+        }
+    ],
+    "ImageId": "${aws_ami}",
+    "InstanceType": "m4.2xlarge",
+    "NetworkInterfaces": [
+        {
+            "DeviceIndex": 0,
+            "AssociatePublicIpAddress": ${associate_public_ip},
+            "Groups": [
+                "${security_group_id}"
+            ]
+        }
+    ],
+    "EbsOptimized": true,
+    "InstanceInitiatedShutdownBehavior": "${shutdown_behavior}"
+}

--- a/conf/templates/example/client.json
+++ b/conf/templates/example/client.json
@@ -1,0 +1,34 @@
+{
+    "KeyName": "${key_name}",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 40,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdf",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 500,
+                "VolumeType": "gp2"
+            } 
+        }
+    ], 
+    "ImageId": "${aws_ami}",
+    "InstanceType": "m4.2xlarge",
+    "NetworkInterfaces": [
+        {
+            "DeviceIndex": 0,
+            "AssociatePublicIpAddress": ${associate_public_ip},
+            "Groups": [
+                "${security_group_id}"
+            ]
+        }
+    ],
+    "EbsOptimized": true,
+    "InstanceInitiatedShutdownBehavior": "${shutdown_behavior}"
+}

--- a/conf/templates/example/metrics.json
+++ b/conf/templates/example/metrics.json
@@ -1,0 +1,34 @@
+{
+    "KeyName": "${key_name}",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 40,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdf",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 500,
+                "VolumeType": "gp2"
+            } 
+        }
+    ], 
+    "ImageId": "${aws_ami}",
+    "InstanceType": "m4.2xlarge",
+    "NetworkInterfaces": [
+        {
+            "DeviceIndex": 0,
+            "AssociatePublicIpAddress": ${associate_public_ip},
+            "Groups": [
+                "${security_group_id}"
+            ]
+        }
+    ],
+    "EbsOptimized": true,
+    "InstanceInitiatedShutdownBehavior": "${shutdown_behavior}"
+}

--- a/conf/templates/example/namenode.json
+++ b/conf/templates/example/namenode.json
@@ -1,0 +1,34 @@
+{
+    "KeyName": "${key_name}",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 40,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdf",
+            "Ebs": {
+                "DeleteOnTermination": true, 
+                "VolumeSize": 500,
+                "VolumeType": "gp2"
+            } 
+        }
+    ], 
+    "ImageId": "${aws_ami}",
+    "InstanceType": "m4.4xlarge",
+    "NetworkInterfaces": [
+        {
+            "DeviceIndex": 0,
+            "AssociatePublicIpAddress": ${associate_public_ip},
+            "Groups": [
+                "${security_group_id}"
+            ]
+        }
+    ],
+    "EbsOptimized": true,
+    "InstanceInitiatedShutdownBehavior": "${shutdown_behavior}"
+}

--- a/conf/templates/example/resourcemanager.json
+++ b/conf/templates/example/resourcemanager.json
@@ -1,0 +1,34 @@
+{
+    "KeyName": "${key_name}",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 40,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdf",
+            "Ebs": {
+                "DeleteOnTermination": true, 
+                "VolumeSize": 500,
+                "VolumeType": "gp2"
+            } 
+        }
+    ], 
+    "ImageId": "${aws_ami}",
+    "InstanceType": "m4.2xlarge",
+    "NetworkInterfaces": [
+        {
+            "DeviceIndex": 0,
+            "AssociatePublicIpAddress": ${associate_public_ip},
+            "Groups": [
+                "${security_group_id}"
+            ]
+        }
+    ],
+    "EbsOptimized": true,
+    "InstanceInitiatedShutdownBehavior": "${shutdown_behavior}"
+}

--- a/conf/templates/example/worker.json
+++ b/conf/templates/example/worker.json
@@ -1,0 +1,58 @@
+{
+    "KeyName": "${key_name}",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+                "DeleteOnTermination": true, 
+                "VolumeSize": 40,
+                "VolumeType": "gp2"
+            } 
+        },
+        {
+            "DeviceName": "/dev/sdf",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 250,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdg",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 250,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdh",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 250,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdi",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 250,
+                "VolumeType": "gp2"
+            }
+        }
+    ], 
+    "ImageId": "${aws_ami}",
+    "InstanceType": "c4.4xlarge",
+    "NetworkInterfaces": [
+        {
+            "DeviceIndex": 0,
+            "AssociatePublicIpAddress": ${associate_public_ip},
+            "Groups": [
+                "${security_group_id}"
+            ]
+        }
+    ],
+    "EbsOptimized": true,
+    "InstanceInitiatedShutdownBehavior": "${shutdown_behavior}"
+}

--- a/conf/templates/example/zookeeper.json
+++ b/conf/templates/example/zookeeper.json
@@ -1,0 +1,34 @@
+{
+    "KeyName": "${key_name}",
+    "BlockDeviceMappings": [
+        {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+                "DeleteOnTermination": true,
+                "VolumeSize": 40,
+                "VolumeType": "gp2"
+            }
+        },
+        {
+            "DeviceName": "/dev/sdf",
+            "Ebs": {
+                "DeleteOnTermination": true, 
+                "VolumeSize": 500,
+                "VolumeType": "gp2"
+            }
+        }
+    ],
+    "ImageId": "${aws_ami}",
+    "InstanceType": "m4.xlarge",
+    "NetworkInterfaces": [
+        {
+            "DeviceIndex": 0,
+            "AssociatePublicIpAddress": ${associate_public_ip},
+            "Groups": [
+                "${security_group_id}"
+            ]
+        }
+    ],
+    "EbsOptimized": true,
+    "InstanceInitiatedShutdownBehavior": "${shutdown_behavior}"
+}

--- a/lib/main.py
+++ b/lib/main.py
@@ -49,7 +49,9 @@ def main():
 
     hosts_path = join(hosts_dir, opts.cluster)
 
-    config = DeployConfig(deploy_path, config_path, hosts_path, checksums_path, opts.cluster)
+    templates_path = join(deploy_path, "conf/templates/")
+
+    config = DeployConfig(deploy_path, config_path, hosts_path, checksums_path, templates_path, opts.cluster)
     config.verify_config(action)
 
     if action == 'config':
@@ -64,8 +66,11 @@ def main():
             cluster = ExistingCluster(config)
             cluster.perform(action)
         elif cluster_type == 'ec2':
-            from muchos.ec2 import Ec2Cluster
-            cluster = Ec2Cluster(config)
+            from muchos.ec2 import Ec2Cluster, Ec2ClusterTemplate
+            if config.has_option('ec2', 'cluster_template'):
+                cluster = Ec2ClusterTemplate(config)
+            else:
+                cluster = Ec2Cluster(config)
             cluster.perform(action)
         else:
             exit('Unknown cluster_type: ' + cluster_type)

--- a/lib/tests/test_config.py
+++ b/lib/tests/test_config.py
@@ -20,7 +20,7 @@ from muchos.config import DeployConfig
 
 def test_ec2_cluster():
     c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
-                     '../conf/checksums', 'mycluster')
+                     '../conf/checksums', '../conf/templates', 'mycluster')
     assert c.checksum_ver('accumulo', '1.9.0') == 'f68a6145029a9ea843b0305c90a7f5f0334d8a8ceeea94734267ec36421fe7fe'
     assert c.checksum('accumulo') == 'df172111698c7a73aa031de09bd5589263a6b824482fbb9b4f0440a16602ed47'
     assert c.get('ec2', 'default_instance_type') == 'm5d.large'
@@ -80,7 +80,7 @@ def test_ec2_cluster():
 
 def test_existing_cluster():
     c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
-                     '../conf/checksums', 'mycluster')
+                     '../conf/checksums', '../conf/templates', 'mycluster')
     c.cluster_type = 'existing'
     assert c.get_cluster_type() == 'existing'
     assert c.node_type_map() == {}
@@ -95,9 +95,27 @@ def test_existing_cluster():
 
 def test_case_sensitive():
     c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
-                     '../conf/checksums', 'mycluster')
+                     '../conf/checksums', '../conf/templates', 'mycluster')
     assert c.has_option('ec2', 'default_instance_type') == True
     assert c.has_option('ec2', 'Default_instance_type') == False
     c.set('nodes', 'CamelCaseWorker', 'worker,fluo')
     c.init_nodes()
     assert c.get_node('CamelCaseWorker') == ['worker', 'fluo']
+
+
+def test_ec2_cluster_template():
+    c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
+                     '../conf/checksums', '../conf/templates', 'mycluster')
+
+    c.set('ec2', 'cluster_template', 'example')
+    c.init_template('../conf/templates')
+    # init_template already calls validate_template, so just ensure that
+    # we've loaded all the expected dictionary items from the example
+    assert 'accumulomaster' in c.cluster_template
+    assert 'client' in c.cluster_template
+    assert 'metrics' in c.cluster_template
+    assert 'namenode' in c.cluster_template
+    assert 'resourcemanager' in c.cluster_template
+    assert 'worker' in c.cluster_template
+    assert 'zookeeper' in c.cluster_template
+    assert 'devices' in c.cluster_template


### PR DESCRIPTION
This PR enables some use cases previously unavailable in muchos, but which may be important to some users.

E.g.,...
* The ability to have distinct, per-host EC2 launch configurations and to leverage a greater variety of instance types
* The ability to utilize persistent, EBS-backed volumes for data storage
* Possibly others

