### PR TITLE
Fixes #268: Setup fails when swarmmanager enabled

### DIFF
--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -35,10 +35,10 @@
       shell: docker swarm join-token -q worker
       register: swarm_token
       changed_when: "'active' not in swarm_status.stdout_lines"
-- hosts: workers
+- hosts: workers:!swarmmanager
   become: yes
   vars:
-    swarm_token: "{{ hostvars[groups['swarmmanager'][0]]['swarm_token']['stdout'] }}"
+    swarm_token_stdout: "{{ hostvars[groups['swarmmanager'][0]]['swarm_token']['stdout'] }}"
     manager_ip: "{{ hostvars[groups['swarmmanager'][0]]['ansible_default_ipv4']['address'] }}"
   tasks:
     - name: get swarm status
@@ -47,6 +47,7 @@
       register: swarm_status
       changed_when: "'active' not in swarm_status.stdout_lines"
     - name: join worker to swarm
-      shell: >
-        docker swarm join --token={{ swarm_token }} {{ manager_ip }}:2377
+      shell: |
+        docker swarm leave || echo "Not part of a swarm."
+        docker swarm join --token={{ swarm_token_stdout }} {{ manager_ip }}:2377
       when: "'active' not in swarm_status.stdout_lines"


### PR DESCRIPTION
* Rename 'swarm_token' task var to 'swarm_token_stdout' to avoid
  clobbering
* Do not run 'join worker to swarm' task on swarmmanager node
* Make the 'join worker to swarm' task idempotent