### PR TITLE
add OMS monitoring support for azure installations

### DIFF
--- a/ansible/common.yml
+++ b/ansible/common.yml
@@ -34,8 +34,15 @@
   tasks:
     - import_tasks: roles/common/tasks/ssh.yml
     - import_tasks: roles/common/tasks/os.yml
-    - import_tasks: roles/common/tasks/azure.yml
+
+    - block:
+      - import_tasks: roles/common/tasks/azure.yml
+      - import_tasks: roles/common/tasks/azure_oms.yml
+        when: az_omsIntegrationNeeded
+      - import_tasks: roles/common/tasks/azure_oms_selinux.yml
+        when: az_omsIntegrationNeeded
       when: cluster_type == 'azure'
+
     - import_tasks: roles/common/tasks/ec2.yml
       when: cluster_type == 'ec2'
     - import_tasks: roles/common/tasks/existing.yml

--- a/ansible/roles/common/files/OMS-collectd.te
+++ b/ansible/roles/common/files/OMS-collectd.te
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module my-collectd 1.0;
+
+require {
+	type collectd_t;
+	type unreserved_port_t;
+	class udp_socket name_bind;
+}
+
+#============= collectd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'nis_enabled'
+allow collectd_t unreserved_port_t:udp_socket name_bind;

--- a/ansible/roles/common/files/OMS-logrotate.te
+++ b/ansible/roles/common/files/OMS-logrotate.te
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module my-logrotate 1.0;
+
+require {
+	type var_t;
+	type logrotate_t;
+	class file getattr;
+}
+
+#============= logrotate_t ==============
+
+#!!!! WARNING: 'var_t' is a base type.
+allow logrotate_t var_t:file getattr;

--- a/ansible/roles/common/files/OMS-reader3.te
+++ b/ansible/roles/common/files/OMS-reader3.te
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module my-reader3 1.0;
+
+require {
+	type collectd_t;
+	type zookeeper_client_port_t;
+	class tcp_socket name_connect;
+}
+
+#============= collectd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'collectd_tcp_network_connect'
+allow collectd_t zookeeper_client_port_t:tcp_socket name_connect;

--- a/ansible/roles/common/files/OMS-writer3.te
+++ b/ansible/roles/common/files/OMS-writer3.te
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module my-writer3 1.0;
+
+require {
+	type collectd_t;
+	type unreserved_port_t;
+	class tcp_socket name_connect;
+}
+
+#============= collectd_t ==============
+
+#!!!! This avc can be allowed using one of the these booleans:
+#     nis_enabled, collectd_tcp_network_connect
+allow collectd_t unreserved_port_t:tcp_socket name_connect;

--- a/ansible/roles/common/tasks/azure_oms.yml
+++ b/ansible/roles/common/tasks/azure_oms.yml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The tasks below have been added to enable integration with Azure Monitor Logs
+
+- name: "Configure required plugins in collectd"
+  template: src=../templates/etc/collectd.d/azure.conf.j2 dest=/etc/collectd.d/azure.conf
+
+- name: "Ensure OMS Agent is installed"
+  shell: eval $(curl -s https://raw.githubusercontent.com/Microsoft/OMS-Agent-for-Linux/master/installer/scripts/onboard_agent.sh | grep -e 'GITHUB_RELEASE=' -e 'BUNDLE_X64=') && wget ${GITHUB_RELEASE}${BUNDLE_X64} && sh ./${BUNDLE_X64} --upgrade
+  args:
+    creates: /opt/microsoft/omsagent/bin/omsadmin.sh
+  register: omsagent_installed
+
+- name: "Configure OMS Agent for workspace"
+  shell: /opt/microsoft/omsagent/bin/omsadmin.sh -w {{ az_logs_id }} -s {{ az_logs_key }}
+  args:
+    creates: /etc/opt/microsoft/omsagent/{{ az_logs_id }}/conf/omsadmin.conf
+  register: omsagent_configured
+
+- name: "Copy oms.conf to collectd folder"
+  copy: remote_src=true src=/etc/opt/microsoft/omsagent/sysconf/omsagent.d/oms.conf dest=/etc/collectd.d/oms.conf
+  notify:
+    - restart collectd
+
+- name: "Copy collectd to OMS folder"
+  copy: remote_src=true src=/etc/opt/microsoft/omsagent/sysconf/omsagent.d/collectd.conf dest=/etc/opt/microsoft/omsagent/{{ az_logs_id }}/conf/omsagent.d/collectd.conf
+  notify:
+    - restart collectd
+
+- name: "Restart service omsagent, in all cases"
+  shell: /opt/microsoft/omsagent/bin/service_control restart {{ az_logs_id }}
+  when: omsagent_configured is succeeded

--- a/ansible/roles/common/tasks/azure_oms_selinux.yml
+++ b/ansible/roles/common/tasks/azure_oms_selinux.yml
@@ -1,0 +1,103 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+- name: Creates directory for SE Policy files
+  file: path=/home/{{ cluster_user}}/SEPolicyFiles state=directory
+
+
+- name: Copy Policy file OMS-collectd.te
+  copy: src=roles/common/files/OMS-collectd.te dest=/home/{{ cluster_user}}/SEPolicyFiles  owner={{ cluster_user }} group={{ cluster_group }}
+
+- name: Copy Policy file OMS-logrotate.te
+  copy: src=roles/common/files/OMS-logrotate.te dest=/home/{{ cluster_user}}/SEPolicyFiles  owner={{ cluster_user }} group={{ cluster_group }}
+
+- name: Copy Policy file OMS-reader3.te
+  copy: src=roles/common/files/OMS-reader3.te dest=/home/{{ cluster_user}}/SEPolicyFiles  owner={{ cluster_user }} group={{ cluster_group }}
+
+- name: Copy Policy file OMS-writer3.te
+  copy: src=roles/common/files/OMS-writer3.te dest=/home/{{ cluster_user}}/SEPolicyFiles  owner={{ cluster_user }} group={{ cluster_group }}
+
+
+
+- name: Run checkmodule for OMS-collectd.te
+  command: checkmodule -M -m -o my-collectd.mod  OMS-collectd.te
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run checkmodule for OMS-reader3.te
+  command: checkmodule -M -m -o my-reader3.mod   OMS-reader3.te
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run checkmodule for OMS-writer3.te
+  command: checkmodule -M -m -o my-writer3.mod   OMS-writer3.te
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run checkmodule for OMS-logrotate.te
+  command: checkmodule -M -m -o my-logrotate.mod OMS-logrotate.te
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+
+
+
+- name: Run semodule_package for OMS-collectd.te
+  command: semodule_package -o OMS-collectd.pp  -m my-collectd.mod
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run semodule_package for OMS-reader3.te
+  command: semodule_package -o OMS-reader3.pp   -m my-reader3.mod
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run semodule_package for OMS-writer3.te
+  command: semodule_package -o OMS-writer3.pp   -m my-writer3.mod
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run semodule_package for OMS-logrotate.te
+  command: semodule_package -o OMS-logrotate.pp -m my-logrotate.mod
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+
+
+
+- name: Run semodule for OMS-collectd.pp
+  command: semodule -i OMS-collectd.pp
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run semodule for OMS-reader3.pp
+  command: semodule -i OMS-reader3.pp
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run semodule for OMS-writer3.pp
+  command: semodule -i OMS-writer3.pp
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+- name: Run semodule for OMS-logrotate.pp
+  command: semodule -i OMS-logrotate.pp
+  args:
+    chdir: /home/{{ cluster_user}}/SEPolicyFiles
+
+
+

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -28,6 +28,8 @@
       - screen
       - patch
       - "{{ java_package }}"
+      - collectd-zookeeper
+      - policycoreutils-python
     state: present
 - name: "configure node shutdown"
   shell: shutdown +{{ shutdown_delay_minutes }} &> {{ user_home }}/.shutdown creates={{ user_home }}/.shutdown
@@ -45,10 +47,10 @@
   file: path={{ hub_home }} recurse=yes owner={{ cluster_user }} group={{ cluster_group}}
   when: install_hub
 - name: "configure collectd"
-  template: src=collectd.conf dest=/etc/collectd.conf
-  when: "'metrics' in groups"
+  template: src=etc/collectd.conf.j2 dest=/etc/collectd.conf
+  when: ('metrics' in groups) or (cluster_type == 'azure')
   notify:
     - restart collectd
 - name: "ensure collectd is running (and enable it at boot)"
   service: name=collectd state=started enabled=yes
-  when: "'metrics' in groups"
+  when: ('metrics' in groups) or (cluster_type == 'azure')

--- a/ansible/roles/common/templates/etc/collectd.conf.j2
+++ b/ansible/roles/common/templates/etc/collectd.conf.j2
@@ -17,6 +17,7 @@ LoadPlugin df
 LoadPlugin load
 LoadPlugin memory
 LoadPlugin network
+LoadPlugin disk
 
 <Plugin cpu>
   ReportByState false
@@ -27,8 +28,14 @@ LoadPlugin network
   MountPoint "/^{{ mount_root }}/"
 </Plugin>
 
+{% if 'metrics' in groups %}
 <Plugin network>
   Server "{{ groups['metrics'][0] }}" "8096"
+</Plugin>
+{% endif %}
+
+<Plugin disk>
+  IgnoreSelected true
 </Plugin>
 
 Include "/etc/collectd.d"

--- a/ansible/roles/common/templates/etc/collectd.d/azure.conf.j2
+++ b/ansible/roles/common/templates/etc/collectd.d/azure.conf.j2
@@ -1,0 +1,15 @@
+{% if inventory_hostname in groups['zookeepers'] -%}
+LoadPlugin zookeeper
+ <Plugin "zookeeper">
+  Host "127.0.0.1"
+  Port "2181"
+ </Plugin>
+{%- endif %}
+
+LoadPlugin statsd
+<Plugin statsd>
+  Host "::"
+  Port "8125"
+  DeleteSets     true
+  TimerPercentile 90.0
+</Plugin>

--- a/conf/muchos.props.example
+++ b/conf/muchos.props.example
@@ -133,6 +133,8 @@ location = westus2
 #azure_fileshare_password = fs_password
 # Optional integration with Azure Log Analytics
 # Workspace ID and key must be updated to enable this.
+# For details on how to get a workspace ID and key, see the link below
+# https://docs.microsoft.com/en-us/azure/azure-monitor/learn/quick-collect-linux-computer#obtain-workspace-id-and-key
 az_omsIntegrationNeeded = False
 #az_logs_id = 
 #az_logs_key = 

--- a/conf/muchos.props.example
+++ b/conf/muchos.props.example
@@ -100,11 +100,11 @@ resource_group = accumulo-rg
 # already exists, it will be used; else a new VNET with this name will be created.
 vnet = vnet1
 # The CIDR prefix used to create the virtual network (VNET).
-vnet_cidr = "10.0.0.0/8"
+vnet_cidr = 10.0.0.0/8
 # A single subnet is created within the VNET and given the following name.
 subnet = subnet1
 # The CIDR prefix used for the single subnet within the virtual network.
-subnet_cidr = "10.1.0.0/16"
+subnet_cidr = 10.1.0.0/16
 # Size of the cluster to provision.
 # A virtual machine scale set (VMSS) with these many VMs will be created.
 # The minimum allowed size for this is 3 nodes.
@@ -131,6 +131,11 @@ location = westus2
 #azure_fileshare = //fileshare-to-mount.file.core.windows.net/path
 #azure_fileshare_username = fs_username
 #azure_fileshare_password = fs_password
+# Optional integration with Azure Log Analytics
+# Workspace ID and key must be updated to enable this.
+az_omsIntegrationNeeded = False
+#az_logs_id = 
+#az_logs_key = 
 
 [existing]
 # Root of data dirs

--- a/lib/muchos/azure.py
+++ b/lib/muchos/azure.py
@@ -37,7 +37,7 @@ class VmssCluster(ExistingCluster):
         azure_config["admin_username"] = config.get("general", "cluster_user")
         azure_config["vmss_name"] = config.cluster_name
         azure_config["deploy_path"] = config.deploy_path
-        azure_config = {k: int(v) if v.isdigit() else v
+        azure_config = {k: VmssCluster._parse_config_value(v)
                         for k, v in azure_config.items()}
         subprocess.call(["ansible-playbook",
                          join(config.deploy_path, "ansible/azure.yml"),
@@ -52,3 +52,12 @@ class VmssCluster(ExistingCluster):
             self.config.cluster_name)
         print('name:', vmss_status.name,
               '\nprovisioning_state:', vmss_status.provisioning_state)
+
+    def _parse_config_value(v):
+        if v.isdigit():
+            return int(v)
+        if v.lower() in ('true', 'yes'):
+            return True
+        if v.lower() in ('false', 'no'):
+            return False
+        return v

--- a/lib/muchos/config.py
+++ b/lib/muchos/config.py
@@ -504,4 +504,7 @@ AZURE_VAR_DEFAULTS = {
   'azure_fileshare': None,
   'azure_fileshare_username': None,
   'azure_fileshare_password': None,
+  'az_omsIntegrationNeeded': None,
+  'az_logs_id': None,
+  'az_logs_key': None
 }


### PR DESCRIPTION
Adds OMS agent to azure installations for monitoring VMs via Azure
Monitor services, specifically log analytics.

Also includes the following enhancements/fixes:
- remove quotes from cidr in muchos.props.example
- add extra-var coercion for boolean values to boolean types

Implements: #282