### PR TITLE
Refactor config

### DIFF
--- a/lib/muchos/config/__init__.py
+++ b/lib/muchos/config/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from muchos.config.base import BaseConfig, SERVICES, OPTIONAL_SERVICES, HOST_VAR_DEFAULTS, PLAY_VAR_DEFAULTS, host_var, play_var, required, default
+from muchos.config.base import BaseConfig, SERVICES, OPTIONAL_SERVICES, HOST_VAR_DEFAULTS, PLAY_VAR_DEFAULTS
 from muchos.config.existing import ExistingDeployConfig
 from muchos.config.ec2 import Ec2DeployConfig
 from muchos.config.azure import AzureDeployConfig, AZURE_VAR_DEFAULTS 

--- a/lib/muchos/config/__init__.py
+++ b/lib/muchos/config/__init__.py
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from muchos.config.base import DeployConfig, SERVICES, OPTIONAL_SERVICES
+from muchos.config.existing import ExistingDeployConfig
+from muchos.config.ec2 import Ec2DeployConfig
+from muchos.config.azure import AzureDeployConfig

--- a/lib/muchos/config/__init__.py
+++ b/lib/muchos/config/__init__.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 #
 
-from muchos.config.base import BaseConfig, SERVICES, OPTIONAL_SERVICES, HOST_VAR_DEFAULTS, PLAY_VAR_DEFAULTS
+from muchos.config.base import BaseConfig, SERVICES, OPTIONAL_SERVICES
 from muchos.config.existing import ExistingDeployConfig
 from muchos.config.ec2 import Ec2DeployConfig
-from muchos.config.azure import AzureDeployConfig, AZURE_VAR_DEFAULTS 
+from muchos.config.azure import AzureDeployConfig
 
 from configparser import ConfigParser
 

--- a/lib/muchos/config/__init__.py
+++ b/lib/muchos/config/__init__.py
@@ -15,7 +15,23 @@
 # limitations under the License.
 #
 
-from muchos.config.base import DeployConfig, SERVICES, OPTIONAL_SERVICES
+from muchos.config.base import BaseConfig, SERVICES, OPTIONAL_SERVICES, HOST_VAR_DEFAULTS, PLAY_VAR_DEFAULTS, host_var, play_var, required, default
 from muchos.config.existing import ExistingDeployConfig
 from muchos.config.ec2 import Ec2DeployConfig
-from muchos.config.azure import AzureDeployConfig
+from muchos.config.azure import AzureDeployConfig, AZURE_VAR_DEFAULTS 
+
+from configparser import ConfigParser
+
+def DeployConfig(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name):
+    c = ConfigParser()
+    c.read(config_path)
+    cluster_type = c.get('general', 'cluster_type')
+
+    if cluster_type == 'existing':
+        return ExistingDeployConfig(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)
+
+    if cluster_type == 'ec2':
+        return Ec2DeployConfig(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)
+
+    if cluster_type == 'azure':
+        return AzureDeployConfig(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)

--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -26,7 +26,6 @@ import glob
 
 
 class AzureDeployConfig(BaseConfig):
-
     def __init__(self, deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name):
         super(AzureDeployConfig, self).__init__(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)
 
@@ -47,7 +46,7 @@ class AzureDeployConfig(BaseConfig):
         pass
 
     def node_type_map(self):
-        node_types = {}
+        return {}
 
     def mount_root(self):
         return self.get('azure', 'mount_root')
@@ -86,13 +85,38 @@ class AzureDeployConfig(BaseConfig):
     def instance_tags(self):
         return {}
 
+    @ansible_host_var
+    @default(None)
+    def azure_fileshare_mount(self):
+        return self.get('azure', 'azure_fileshare_mount')
 
-AZURE_VAR_DEFAULTS = {
-  'azure_fileshare_mount': None,
-  'azure_fileshare': None,
-  'azure_fileshare_username': None,
-  'azure_fileshare_password': None,
-  'az_omsIntegrationNeeded': None,
-  'az_logs_id': None,
-  'az_logs_key': None
-}
+    @ansible_host_var
+    @default(None)
+    def azure_fileshare(self):
+        return self.get('azure', 'azure_fileshare')
+    
+    @ansible_host_var
+    @default(None)
+    def azure_fileshare_username(self):
+        return self.get('azure', 'azure_fileshare_username')
+
+    @ansible_host_var
+    @default(None)
+    def azure_fileshare_password(self):
+        return self.get('azure', 'azure_fileshare_password')
+
+    @ansible_host_var(name='az_omsIntegrationNeeded')
+    @default(False)
+    @is_valid(is_in([True, False]))
+    def omsIntegrationNeeded(self):
+        return self.getboolean('azure', 'az_omsIntegrationNeeded')
+
+    @ansible_host_var(name='az_logs_id')
+    @default(None)
+    def logs_id(self):
+        return self.get('azure', 'az_logs_id')
+
+    @ansible_host_var(name='az_logs_key')
+    @default(None)
+    def logs_key(self):
+        return self.get('azure', 'az_logs_key')

--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -1,0 +1,96 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from muchos.config import DeployConfig
+from sys import exit
+from muchos.util import get_ephemeral_devices, get_arch
+import os
+import json
+import glob
+
+
+class AzureDeployConfig(DeployConfig):
+
+    def __init__(self, deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name):
+        super(AzureDeployConfig, self).__init__(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)
+
+    def verify_config(self, action):
+        self._verify_config(action)
+
+        proxy = self.get('general', 'proxy_hostname')
+        cluster_type = self.get('general', 'cluster_type')
+        if cluster_type not in ['azure']:
+            if not proxy:
+                exit("ERROR - proxy.hostname must be set in muchos.props")
+
+            if proxy not in self.node_d:
+                exit("ERROR - The proxy (set by property proxy_hostname={0}) cannot be found in 'nodes' section of "
+                     "muchos.props".format(proxy))
+
+    def verify_launch(self):
+        pass
+
+    def node_type_map(self):
+        node_types = {}
+
+    def mount_root(self):
+        return self.get('azure', 'mount_root')
+
+    def fstype(self):
+        retval = None
+        return retval
+
+    def force_format(self):
+        retval = 'no'
+        return retval
+
+    def data_dirs_common(self, nodeType):
+        data_dirs = []
+
+        num_disks = int(self.get("azure", "numdisks"))
+        range_var = num_disks + 1
+        for diskNum in range(1, range_var):
+            data_dirs.append(self.get("azure", "mount_root") +
+                                str(diskNum))
+
+        return data_dirs
+
+    def metrics_drive_ids(self):
+        drive_ids = []
+        range_var = int(self.get("azure", "numdisks")) + 1
+        for i in range(1, range_var):
+            drive_ids.append(self.get("azure", "metrics_drive_root") +
+                                str(i))
+        return drive_ids
+
+    def shutdown_delay_minutes(self):
+        retval = '0'
+        return retval
+
+    def instance_tags(self):
+        return {}
+
+
+AZURE_VAR_DEFAULTS = {
+  'azure_fileshare_mount': None,
+  'azure_fileshare': None,
+  'azure_fileshare_username': None,
+  'azure_fileshare_password': None,
+  'az_omsIntegrationNeeded': None,
+  'az_logs_id': None,
+  'az_logs_key': None
+}

--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from muchos.config import DeployConfig
+from muchos.config import BaseConfig, host_var, play_var, extra_var, default
 from sys import exit
 from muchos.util import get_ephemeral_devices, get_arch
 import os
@@ -23,7 +23,7 @@ import json
 import glob
 
 
-class AzureDeployConfig(DeployConfig):
+class AzureDeployConfig(BaseConfig):
 
     def __init__(self, deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name):
         super(AzureDeployConfig, self).__init__(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)

--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -70,13 +70,6 @@ class AzureDeployConfig(BaseConfig):
                                 str(i))
         return drive_ids
 
-    def shutdown_delay_minutes(self):
-        retval = '0'
-        return retval
-
-    def instance_tags(self):
-        return {}
-
     @ansible_host_var
     @default(None)
     def azure_fileshare_mount(self):

--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 
-from muchos.config import BaseConfig, host_var, play_var, extra_var, default
+from muchos.config import BaseConfig
+from muchos.config.decorators import *
+from muchos.config.validators import *
 from sys import exit
 from muchos.util import get_ephemeral_devices, get_arch
 import os

--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -51,14 +51,6 @@ class AzureDeployConfig(BaseConfig):
     def mount_root(self):
         return self.get('azure', 'mount_root')
 
-    def fstype(self):
-        retval = None
-        return retval
-
-    def force_format(self):
-        retval = 'no'
-        return retval
-
     def data_dirs_common(self, nodeType):
         data_dirs = []
 

--- a/lib/muchos/config/base.py
+++ b/lib/muchos/config/base.py
@@ -89,8 +89,6 @@ _PLAY_VAR_DEFAULTS = {
   'fluo_worker_mem_mb': None,
   'fluo_worker_threads': None,
   'fluo_yarn_sha256': None,
-  'force_format': None,
-  'fstype': None,
   'hadoop_sha256': None,
   'hub_version': '2.2.3',
   'hub_home': '"{{ install_dir }}/hub-linux-amd64-{{ hub_version }}"',
@@ -213,16 +211,6 @@ class BaseConfig(ConfigParser, metaclass=ABCMeta):
     @abstractmethod
     @ansible_play_var
     def mount_root(self):
-        raise NotImplementedError()
-
-    @abstractmethod
-    @ansible_play_var
-    def fstype(self):
-        raise NotImplementedError()
-
-    @abstractmethod
-    @ansible_play_var
-    def force_format(self):
         raise NotImplementedError()
 
     @abstractmethod

--- a/lib/muchos/config/base.py
+++ b/lib/muchos/config/base.py
@@ -47,7 +47,7 @@ class BaseConfig(ConfigParser, metaclass=ABCMeta):
         self.checksums_d = None
         self._init_nodes()
 
-    def host_vars(self):
+    def ansible_host_vars(self):
         vars = HOST_VAR_DEFAULTS.copy()
 
         # only render host_vars for base and cluster specific config
@@ -58,7 +58,7 @@ class BaseConfig(ConfigParser, metaclass=ABCMeta):
                   get_ansible_vars('host'))})
         return vars
 
-    def play_vars(self):
+    def ansible_play_vars(self):
         vars = PLAY_VAR_DEFAULTS.copy()
 
         # populate common software checksums

--- a/lib/muchos/config/decorators.py
+++ b/lib/muchos/config/decorators.py
@@ -56,10 +56,14 @@ def default(val):
     def _default(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            res = func(*args, **kwargs)
-            if res in [None, 0, ''] or len(res) == 0:
+            try:
+                res = func(*args, **kwargs)
+            except:
                 return val
-            return res
+            else:
+                if res in [None, 0, ''] or len(res) == 0:
+                    return val
+                return res
         return wrapper
     return _default
 

--- a/lib/muchos/config/decorators.py
+++ b/lib/muchos/config/decorators.py
@@ -32,15 +32,15 @@ def get_ansible_vars(var_type):
     return _ansible_vars.get(var_type)
 
 # ansible hosts inventory variables
-def host_var(name=None):
+def ansible_host_var(name=None):
     return ansible_var_decorator('host', name)
 
 # ansible group/all variables
-def play_var(name=None):
+def ansible_play_var(name=None):
     return ansible_var_decorator('play', name)
 
 # ansible extra variables
-def extra_var(name=None):
+def ansible_extra_var(name=None):
     return ansible_var_decorator('extra', name)
 
 def ansible_var_decorator(var_type, name):

--- a/lib/muchos/config/decorators.py
+++ b/lib/muchos/config/decorators.py
@@ -1,0 +1,97 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from collections.abc import Iterable
+from functools import wraps
+
+
+_host_vars = []
+_play_vars = []
+_extra_vars = []
+_ansible_vars = dict(
+    host=[],
+    play=[],
+    extra=[]
+)
+
+def get_ansible_vars(var_type):
+    return _ansible_vars.get(var_type)
+
+# ansible hosts inventory variables
+def host_var(name=None):
+    return ansible_var_decorator('host', name)
+
+# ansible group/all variables
+def play_var(name=None):
+    return ansible_var_decorator('play', name)
+
+# ansible extra variables
+def extra_var(name=None):
+    return ansible_var_decorator('extra', name)
+
+def ansible_var_decorator(var_type, name):
+    def _decorator(func):
+        if getattr(func, '__isabstractmethod__', False):
+            raise Exception("{}: cannot decorate an abstract method as play_var".format(func.__qualname__))
+
+        _ansible_vars[var_type].append((name if isinstance(name, str) else func.__name__, func.__qualname__.split('.')[0], func.__name__))
+        return func
+
+    if callable(name):
+        return _decorator(name)
+    return _decorator
+
+def default(val):
+    def _default(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            res = func(*args, **kwargs)
+            if res in [None, 0, ''] or len(res) == 0:
+                return val
+            return res
+        return wrapper
+    return _default
+
+def required(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        res = func(*args, **kwargs)
+        if res in [None, 0, ''] or len(res) == 0:
+            raise ConfigMissingError(func.__name__)
+        return res
+    return wrapper
+
+def is_valid(validators):
+    if not isinstance(validators, Iterable):
+        validators = [validators]
+    def _validate(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            res = func(*args, **kwargs)
+            failed_checks = list(filter(lambda f: f(res) is not True, validators))
+            if len(failed_checks) > 0:
+                raise Exception("{}={} checked validation {}".format(
+                    func.__name__, res,
+                    [str(v) for v in failed_checks]))
+            return res
+        return wrapper
+    return _validate
+
+class ConfigMissingError(Exception):
+    def __init__(self, name):
+        super(ConfigMissingError, self).__init__("{} is missing from the configuration".format(name))
+

--- a/lib/muchos/config/decorators.py
+++ b/lib/muchos/config/decorators.py
@@ -45,9 +45,6 @@ def ansible_extra_var(name=None):
 
 def ansible_var_decorator(var_type, name):
     def _decorator(func):
-        if getattr(func, '__isabstractmethod__', False):
-            raise Exception("{}: cannot decorate an abstract method as play_var".format(func.__qualname__))
-
         _ansible_vars[var_type].append((name if isinstance(name, str) else func.__name__, func.__qualname__.split('.')[0], func.__name__))
         return func
 

--- a/lib/muchos/config/ec2.py
+++ b/lib/muchos/config/ec2.py
@@ -81,11 +81,15 @@ class Ec2DeployConfig(BaseConfig):
     def mount_root(self):
         return '/media/' + self.ephemeral_root
 
+    @ansible_play_var
+    @default('ext3')
     def fstype(self):
-        return self.get('ec2', 'fstype', fallback='ext3')
+        return self.get('ec2', 'fstype')
 
+    @ansible_play_var
+    @default('no')
     def force_format(self):
-        return self.get('ec2', 'force_format', fallback='no')
+        return self.get('ec2', 'force_format')
 
     def data_dirs_common(self, nodeType):
         return self.node_type_map()[nodeType]['mounts']

--- a/lib/muchos/config/ec2.py
+++ b/lib/muchos/config/ec2.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-from muchos.config import DeployConfig, SERVICES, OPTIONAL_SERVICES
+from muchos.config import SERVICES, OPTIONAL_SERVICES
+from muchos.config import BaseConfig, host_var, play_var, extra_var, default
 from sys import exit
 from muchos.util import get_ephemeral_devices, get_arch
 import os
@@ -23,11 +24,14 @@ import json
 import glob
 
 
-class Ec2DeployConfig(DeployConfig):
+class Ec2DeployConfig(BaseConfig):
 
     def __init__(self, deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name):
         super(Ec2DeployConfig, self).__init__(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)
+        self.sg_name = cluster_name + '-group'
+        self.ephemeral_root = 'ephemeral'
         self.cluster_template_d = None
+        self.metrics_drive_root = 'media-' + self.ephemeral_root
         self.init_template(templates_path)
 
     def verify_config(self, action):
@@ -59,6 +63,7 @@ class Ec2DeployConfig(DeployConfig):
     def max_ephemeral(self):
         return max((len(self.default_ephemeral_devices()), len(self.worker_ephemeral_devices())))
 
+    @host_var(name='ec2_node_type_map')
     def node_type_map(self):
         if self.cluster_template_d:
             return self.cluster_template_d['devices']

--- a/lib/muchos/config/ec2.py
+++ b/lib/muchos/config/ec2.py
@@ -1,0 +1,174 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from muchos.config import DeployConfig, SERVICES, OPTIONAL_SERVICES
+from sys import exit
+from muchos.util import get_ephemeral_devices, get_arch
+import os
+import json
+import glob
+
+
+class Ec2DeployConfig(DeployConfig):
+
+    def __init__(self, deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name):
+        super(Ec2DeployConfig, self).__init__(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)
+        self.cluster_template_d = None
+        self.init_template(templates_path)
+
+    def verify_config(self, action):
+        self._verify_config(action)
+
+    def verify_launch(self):
+        self.verify_instance_type(self.get('ec2', 'default_instance_type'))
+        self.verify_instance_type(self.get('ec2', 'worker_instance_type'))
+
+    def init_nodes(self):
+        self.node_d = {}
+        for (hostname, value) in self.items('nodes'):
+            if hostname in self.node_d:
+                exit('Hostname {0} already exists twice in nodes'.format(hostname))
+            service_list = []
+            for service in value.split(','):
+                if service in SERVICES:
+                    service_list.append(service)
+                else:
+                    exit('Unknown service "%s" declared for node %s' % (service, hostname))
+            self.node_d[hostname] = service_list
+
+    def default_ephemeral_devices(self):
+        return get_ephemeral_devices(self.get('ec2', 'default_instance_type'))
+
+    def worker_ephemeral_devices(self):
+        return get_ephemeral_devices(self.get('ec2', 'worker_instance_type'))
+
+    def max_ephemeral(self):
+        return max((len(self.default_ephemeral_devices()), len(self.worker_ephemeral_devices())))
+
+    def node_type_map(self):
+        if self.cluster_template_d:
+            return self.cluster_template_d['devices']
+
+        node_types = {}
+
+        node_list = [('default', self.default_ephemeral_devices()), ('worker', self.worker_ephemeral_devices())]
+
+        for (ntype, devices) in node_list:
+            node_types[ntype] = {'mounts': self.mounts(len(devices)), 'devices': devices}
+
+        return node_types
+
+    def mount_root(self):
+        return '/media/' + self.ephemeral_root
+
+    def fstype(self):
+        return self.get('ec2', 'fstype', fallback='ext3')
+
+    def force_format(self):
+        return self.get('ec2', 'force_format', fallback='no')
+
+    def data_dirs_common(self, nodeType):
+        return self.node_type_map()[nodeType]['mounts']
+
+    def metrics_drive_ids(self):
+        drive_ids = []
+        for i in range(0, self.max_ephemeral()):
+            drive_ids.append(self.metrics_drive_root + str(i))
+        return drive_ids
+
+    def shutdown_delay_minutes(self):
+        return self.get("ec2", "shutdown_delay_minutes")
+
+    def verify_instance_type(self, instance_type):
+        if not self.cluster_template_d:
+            if get_arch(instance_type) == 'pvm':
+                exit("ERROR - Configuration contains instance type '{0}' that uses pvm architecture."
+                     "Only hvm architecture is supported!".format(instance_type))
+
+    def instance_tags(self):
+        retd = {}
+        if self.has_option('ec2', 'instance_tags'):
+            value = self.get('ec2', 'instance_tags')
+            if value:
+                for kv in value.split(','):
+                    (key, val) = kv.split(':')
+                    retd[key] = val
+        return retd
+
+    def init_template(self, templates_path):
+        if self.has_option('ec2', 'cluster_template'):
+            template_id = self.get('ec2', 'cluster_template')
+            template_path = os.path.join(templates_path, template_id)
+            if os.path.exists(template_path):
+                self.cluster_template_d = {'id': template_id}
+                self.load_template_ec2_requests(template_path)
+                self.load_template_device_map(template_path)
+            self.validate_template()
+
+    def load_template_ec2_requests(self, template_dir):
+        for json_path in glob.glob(os.path.join(template_dir, '*.json')):
+            service = os.path.basename(json_path).rsplit('.', 1)[0]
+            if service not in SERVICES:
+                exit("ERROR - Template '{0}' has unrecognized option '{1}'. Must be one of {2}".format(
+                    self.cluster_template_d['id'], service, str(SERVICES)))
+            with open(json_path, 'r') as json_file:
+                # load as string, so we can use string.Template to inject config values
+                self.cluster_template_d[service] = json_file.read()
+
+    def load_template_device_map(self, template_dir):
+        device_map_path = os.path.join(template_dir, 'devices')
+        if not os.path.isfile(device_map_path):
+            exit("ERROR - template '{0}' is missing 'devices' config".format(self.cluster_template_d['id']))
+        with open(device_map_path, 'r') as json_file:
+            self.cluster_template_d['devices'] = json.load(json_file)
+
+    def validate_template(self):
+        if not self.cluster_template_d:
+            exit("ERROR - Template '{0}' is not defined!".format(self.get('ec2', 'cluster_template')))
+
+        if 'worker' not in self.cluster_template_d:
+            exit("ERROR - '{0}' template config is invalid. No 'worker' launch request is defined".format(
+                self.cluster_template_d['id']))
+
+        if 'worker' not in self.cluster_template_d['devices']:
+            exit("ERROR - '{0}' template is invalid. The devices file must have a 'worker' device map".format(
+                self.cluster_template_d['id']))
+
+        if 'default' not in self.cluster_template_d['devices']:
+            exit("ERROR - '{0}' template is invalid. The devices file must have a 'default' device map".format(
+                self.cluster_template_d['id']))
+
+        # Validate the selected launch template for each host
+
+        worker_count = 0
+        for hostname in self.node_d:
+            # first service listed denotes the selected template
+            selected_ec2_request = self.node_d[hostname][0]
+            if 'worker' == selected_ec2_request:
+                worker_count = worker_count + 1
+            else:
+                if 'worker' in self.node_d[hostname]:
+                    exit("ERROR - '{0}' node config is invalid. The 'worker' service should be listed first".format(
+                        hostname))
+            if selected_ec2_request not in self.cluster_template_d:
+                if len(self.node_d[hostname]) > 1:
+                    print('Hint: In template mode, the first service listed for a host denotes its EC2 template')
+                exit("ERROR - '{0}' node config is invalid. No EC2 template defined for the '{1}' service".format(
+                    hostname, selected_ec2_request))
+
+        if worker_count == 0:
+            exit("ERROR - No worker instances are defined for template '{0}'".format(self.cluster_template_d['id']))

--- a/lib/muchos/config/ec2.py
+++ b/lib/muchos/config/ec2.py
@@ -16,8 +16,10 @@
 #
 
 from muchos.config import SERVICES, OPTIONAL_SERVICES
-from muchos.config import BaseConfig, host_var, play_var, extra_var, default
+from muchos.config.base import BaseConfig
 from sys import exit
+from muchos.config.decorators import *
+from muchos.config.validators import *
 from muchos.util import get_ephemeral_devices, get_arch
 import os
 import json
@@ -63,7 +65,6 @@ class Ec2DeployConfig(BaseConfig):
     def max_ephemeral(self):
         return max((len(self.default_ephemeral_devices()), len(self.worker_ephemeral_devices())))
 
-    @host_var(name='ec2_node_type_map')
     def node_type_map(self):
         if self.cluster_template_d:
             return self.cluster_template_d['devices']

--- a/lib/muchos/config/existing.py
+++ b/lib/muchos/config/existing.py
@@ -43,14 +43,6 @@ class ExistingDeployConfig(BaseConfig):
     def mount_root(self):
         return self.get('existing', 'mount_root')
 
-    def fstype(self):
-        retval = None
-        return retval
-
-    def force_format(self):
-        retval = 'no'
-        return retval
-
     def data_dirs_common(self, nodeType):
         return self.get('existing', 'data_dirs').split(",")
 

--- a/lib/muchos/config/existing.py
+++ b/lib/muchos/config/existing.py
@@ -58,8 +58,7 @@ class ExistingDeployConfig(BaseConfig):
         return self.get("existing", "metrics_drive_ids").split(",")
 
     def shutdown_delay_minutes(self):
-        retval = '0'
-        return retval
+        return '0'
 
     def instance_tags(self):
         return {}

--- a/lib/muchos/config/existing.py
+++ b/lib/muchos/config/existing.py
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from muchos.config import DeployConfig
+from sys import exit
+from muchos.util import get_ephemeral_devices, get_arch
+import os
+import json
+import glob
+
+
+class ExistingDeployConfig(DeployConfig):
+
+    def __init__(self, deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name):
+        super(ExistingDeployConfig, self).__init__(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)
+
+    def verify_config(self, action):
+        self._verify_config(action)
+
+    def verify_launch(self):
+        pass
+
+    def node_type_map(self):
+        node_types = {}
+        return node_types
+
+    def mount_root(self):
+        return self.get('existing', 'mount_root')
+
+    def fstype(self):
+        retval = None
+        return retval
+
+    def force_format(self):
+        retval = 'no'
+        return retval
+
+    def data_dirs_common(self, nodeType):
+        return self.get('existing', 'data_dirs').split(",")
+
+    def metrics_drive_ids(self):
+        return self.get("existing", "metrics_drive_ids").split(",")
+
+    def shutdown_delay_minutes(self):
+        retval = '0'
+        return retval
+
+    def instance_tags(self):
+        return {}

--- a/lib/muchos/config/existing.py
+++ b/lib/muchos/config/existing.py
@@ -48,9 +48,3 @@ class ExistingDeployConfig(BaseConfig):
 
     def metrics_drive_ids(self):
         return self.get("existing", "metrics_drive_ids").split(",")
-
-    def shutdown_delay_minutes(self):
-        return '0'
-
-    def instance_tags(self):
-        return {}

--- a/lib/muchos/config/existing.py
+++ b/lib/muchos/config/existing.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from muchos.config import DeployConfig
+from muchos.config import BaseConfig, host_var, play_var, extra_var, default
 from sys import exit
 from muchos.util import get_ephemeral_devices, get_arch
 import os
@@ -23,7 +23,7 @@ import json
 import glob
 
 
-class ExistingDeployConfig(DeployConfig):
+class ExistingDeployConfig(BaseConfig):
 
     def __init__(self, deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name):
         super(ExistingDeployConfig, self).__init__(deploy_path, config_path, hosts_path, checksums_path, templates_path, cluster_name)

--- a/lib/muchos/config/existing.py
+++ b/lib/muchos/config/existing.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 #
 
-from muchos.config import BaseConfig, host_var, play_var, extra_var, default
+from muchos.config import BaseConfig
 from sys import exit
+from muchos.config.decorators import *
+from muchos.config.validators import *
 from muchos.util import get_ephemeral_devices, get_arch
 import os
 import json

--- a/lib/muchos/config/validators.py
+++ b/lib/muchos/config/validators.py
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class _validator(object):
+    def __init__(self, f, msg):
+        self.f = f
+        self.msg = msg
+
+    def __call__(self, n):
+        return self.f(n)
+
+    def __str__(self):
+        return self.msg
+
+
+def greater_than(val):
+    return _validator(
+        lambda n: n > val,
+        "must be greater than {}".format(val))
+
+def less_than(val):
+    return _validator(
+        lambda n: n < val,
+        "must be less than {}".format(val))
+
+def equals(val):
+    return _validator(
+        lambda n: n == val,
+        "must equal {}".format(val))
+
+def contains(val):
+    return _validator(
+        lambda n: val in n,
+        "must contain {}".format(val))
+
+def is_in(val):
+    return _validator(
+        lambda n: n in val,
+        "must be in {}".format(val))

--- a/lib/muchos/config/validators.py
+++ b/lib/muchos/config/validators.py
@@ -51,3 +51,8 @@ def is_in(val):
     return _validator(
         lambda n: n in val,
         "must be in {}".format(val))
+
+def is_type(t):
+    return _validator(
+        lambda n: isinstance(n, t),
+        "must be of type {}".format(t))

--- a/lib/muchos/existing.py
+++ b/lib/muchos/existing.py
@@ -23,9 +23,6 @@ from os.path import isfile, join
 from sys import exit
 from os import listdir
 
-from .config import HOST_VAR_DEFAULTS, PLAY_VAR_DEFAULTS, AZURE_VAR_DEFAULTS
-
-
 class ExistingCluster:
 
     def __init__(self, config):
@@ -40,8 +37,6 @@ class ExistingCluster:
 
         host_vars = config.ansible_host_vars()
         play_vars = config.ansible_play_vars()
-
-        azure_vars = config.ansible_extra_vars(default_map=AZURE_VAR_DEFAULTS)
 
         for k,v in host_vars.items():
             host_vars[k] = self.config.resolve_value(k, default=v)
@@ -126,8 +121,6 @@ class ExistingCluster:
 
             print("\n[all:vars]", file=hosts_file)
             for (name, value) in sorted(host_vars.items()):
-                print("{0} = {1}".format(name, value), file=hosts_file)
-            for (name, value) in sorted(azure_vars.items()):
                 print("{0} = {1}".format(name, value), file=hosts_file)
 
         with open(join(config.deploy_path, "ansible/group_vars/all"), 'w') as play_vars_file:

--- a/lib/muchos/existing.py
+++ b/lib/muchos/existing.py
@@ -38,36 +38,15 @@ class ExistingCluster:
         config = self.config
         print('Syncing ansible directory on {0} cluster proxy node'.format(config.cluster_name))
 
-        host_vars = HOST_VAR_DEFAULTS
-        play_vars = PLAY_VAR_DEFAULTS
+        host_vars = config.ansible_host_vars()
+        play_vars = config.ansible_play_vars()
 
-        azure_vars = AZURE_VAR_DEFAULTS
+        azure_vars = config.ansible_extra_vars(default_map=AZURE_VAR_DEFAULTS)
 
-        for section in ("general", "ansible-vars", config.get('performance', 'profile'), "azure"):
-            for (name, value) in config.items(section):
-                if name not in ('proxy_hostname', 'proxy_socks_port'):
-                    if name in host_vars:
-                        host_vars[name] = value
-                    if name in play_vars:
-                        play_vars[name] = value
-                    if name in azure_vars:
-                        azure_vars[name] = value
-
-        play_vars['accumulo_sha256'] = config.checksum('accumulo')
-        play_vars['fluo_sha256'] = config.checksum('fluo')
-        play_vars['fluo_yarn_sha256'] = config.checksum('fluo_yarn')
-        play_vars['hadoop_sha256'] = config.checksum('hadoop')
-        play_vars['spark_sha256'] = config.checksum('spark')
-        play_vars['zookeeper_sha256'] = config.checksum('zookeeper')
-        play_vars["shutdown_delay_minutes"] = config.shutdown_delay_minutes()
-        play_vars["metrics_drive_ids"] = config.metrics_drive_ids()
-        play_vars["mount_root"] = config.mount_root()
-        play_vars["node_type_map"] = config.node_type_map()
-        play_vars["fstype"] = config.fstype()
-        play_vars["force_format"] = config.force_format()
-        host_vars['worker_data_dirs'] = str(config.worker_data_dirs())
-        host_vars['default_data_dirs'] = str(config.default_data_dirs())
-        host_vars['java_product_version'] = str(config.java_product_version())
+        for k,v in host_vars.items():
+            host_vars[k] = self.config.resolve_value(k, default=v)
+        for k,v in play_vars.items():
+            play_vars[k] = self.config.resolve_value(k, default=v)
 
         with open(join(config.deploy_path, "ansible/site.yml"), 'w') as site_file:
             print("- import_playbook: common.yml", file=site_file)

--- a/lib/tests/azure/__init__.py
+++ b/lib/tests/azure/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+

--- a/lib/tests/azure/test_config.py
+++ b/lib/tests/azure/test_config.py
@@ -47,7 +47,6 @@ def test_azure_cluster():
     assert c.has_option('azure', 'subnet_cidr')
     assert c.has_option('azure', 'numnodes')
     assert c.has_option('azure', 'location')
-    assert c.instance_tags() == {}
     assert len(c.nodes()) == 6
     assert c.get_node('leader1') == ['namenode', 'resourcemanager', 'accumulomaster', 'zookeeper']
     assert c.get_node('leader2') == ['metrics']

--- a/lib/tests/azure/test_config.py
+++ b/lib/tests/azure/test_config.py
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from muchos.config import AzureDeployConfig
+
+
+def test_azure_cluster():
+    c = AzureDeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
+                     '../conf/checksums', '../conf/templates', 'mycluster')
+
+    # since we are sharing a single muchos.props.example file, we need
+    # to stub the cluster type to be azure (as the file itself has a default of ec2)
+
+    c.cluster_type = 'azure'
+
+    assert c.checksum_ver('accumulo', '1.9.0') == 'f68a6145029a9ea843b0305c90a7f5f0334d8a8ceeea94734267ec36421fe7fe'
+    assert c.checksum('accumulo') == 'df172111698c7a73aa031de09bd5589263a6b824482fbb9b4f0440a16602ed47'
+    assert c.get('azure', 'vm_sku') == 'Standard_D8s_v3'
+    assert c.get('azure', 'managed_disk_type') == 'Standard_LRS'
+    assert c.user_home() == '/home/centos'
+    assert c.mount_root() == '/var/data'
+    assert c.force_format() == 'no'
+    assert c.worker_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
+    assert c.default_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
+    assert c.metrics_drive_ids() == ['var-data1', 'var-data2', 'var-data3']
+    assert c.shutdown_delay_minutes() == '0'
+    assert c.mounts(2) == ['/var/data0', '/var/data1']
+    assert c.node_type('worker1') == 'worker'
+    assert c.node_type('leader1') == 'default'
+    assert c.has_option('azure', 'resource_group')
+    assert c.has_option('azure', 'vnet')
+    assert c.has_option('azure', 'vnet_cidr')
+    assert c.has_option('azure', 'subnet')
+    assert c.has_option('azure', 'subnet_cidr')
+    assert c.has_option('azure', 'numnodes')
+    assert c.has_option('azure', 'location')
+    assert c.instance_tags() == {}
+    assert len(c.nodes()) == 6
+    assert c.get_node('leader1') == ['namenode', 'resourcemanager', 'accumulomaster', 'zookeeper']
+    assert c.get_node('leader2') == ['metrics']
+    assert c.get_node('worker1') == ['worker', 'swarmmanager']
+    assert c.get_node('worker2') == ['worker']
+    assert c.get_node('worker3') == ['worker']
+    assert c.has_service('accumulomaster')
+    assert not c.has_service('fluo')
+    assert c.get_service_hostnames('worker') == ['worker1', 'worker2', 'worker3', 'worker4']
+    assert c.get_service_hostnames('zookeeper') == ['leader1']
+    assert c.get_hosts() == {'leader2': ('10.0.0.1', None), 'leader1': ('10.0.0.0', '23.0.0.0'),
+                             'worker1': ('10.0.0.2', None), 'worker3': ('10.0.0.4', None),
+                             'worker2': ('10.0.0.3', None), 'worker4': ('10.0.0.5', None)}
+    assert c.get_public_ip('leader1') == '23.0.0.0'
+    assert c.get_private_ip('leader1') == '10.0.0.0'
+    assert c.cluster_name == 'mycluster'
+    assert c.get_cluster_type() == 'azure'
+    assert c.version("accumulo").startswith('2.')
+    assert c.version("fluo").startswith('1.')
+    assert c.version("hadoop").startswith('3.')
+    assert c.version("zookeeper").startswith('3.')
+    assert c.get_service_private_ips("worker") == ['10.0.0.2', '10.0.0.3', '10.0.0.4', '10.0.0.5']
+    assert c.get('general', 'proxy_hostname') == "leader1"
+    assert c.proxy_public_ip() == "23.0.0.0"
+    assert c.proxy_private_ip() == "10.0.0.0"
+    assert c.get('general', 'cluster_user') == "centos"
+    assert c.get('general', 'cluster_group') == "centos"
+    assert c.get_non_proxy() == [('10.0.0.1', 'leader2'), ('10.0.0.2', 'worker1'), ('10.0.0.3', 'worker2'),
+                                 ('10.0.0.4', 'worker3'), ('10.0.0.5', 'worker4')]
+    assert c.get_host_services() == [('leader1', 'namenode resourcemanager accumulomaster zookeeper'),
+                                     ('leader2', 'metrics'),
+                                     ('worker1', 'worker swarmmanager'),
+                                     ('worker2', 'worker'),
+                                     ('worker3', 'worker'),
+                                     ('worker4', 'worker')]

--- a/lib/tests/azure/test_config.py
+++ b/lib/tests/azure/test_config.py
@@ -33,7 +33,6 @@ def test_azure_cluster():
     assert c.get('azure', 'managed_disk_type') == 'Standard_LRS'
     assert c.user_home() == '/home/centos'
     assert c.mount_root() == '/var/data'
-    assert c.force_format() == 'no'
     assert c.worker_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
     assert c.default_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
     assert c.metrics_drive_ids() == ['var-data1', 'var-data2', 'var-data3']

--- a/lib/tests/ec2/__init__.py
+++ b/lib/tests/ec2/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+

--- a/lib/tests/ec2/test_config.py
+++ b/lib/tests/ec2/test_config.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from muchos.config import DeployConfig, ExistingDeployConfig, Ec2DeployConfig, AzureDeployConfig
+from muchos.config import Ec2DeployConfig
 
 
 def test_ec2_cluster():
@@ -79,89 +79,6 @@ def test_ec2_cluster():
                                      ('worker2', 'worker'),
                                      ('worker3', 'worker'),
                                      ('worker4', 'worker')]
-
-
-def test_azure_cluster():
-    c = AzureDeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
-                     '../conf/checksums', '../conf/templates', 'mycluster')
-
-    # since we are sharing a single muchos.props.example file, we need
-    # to stub the cluster type to be azure (as the file itself has a default of ec2)
-
-    c.cluster_type = 'azure'
-
-    assert c.checksum_ver('accumulo', '1.9.0') == 'f68a6145029a9ea843b0305c90a7f5f0334d8a8ceeea94734267ec36421fe7fe'
-    assert c.checksum('accumulo') == 'df172111698c7a73aa031de09bd5589263a6b824482fbb9b4f0440a16602ed47'
-    assert c.get('azure', 'vm_sku') == 'Standard_D8s_v3'
-    assert c.get('azure', 'managed_disk_type') == 'Standard_LRS'
-    assert c.user_home() == '/home/centos'
-    assert c.mount_root() == '/var/data'
-    assert c.force_format() == 'no'
-    assert c.worker_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
-    assert c.default_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
-    assert c.metrics_drive_ids() == ['var-data1', 'var-data2', 'var-data3']
-    assert c.shutdown_delay_minutes() == '0'
-    assert c.mounts(2) == ['/var/data0', '/var/data1']
-    assert c.node_type('worker1') == 'worker'
-    assert c.node_type('leader1') == 'default'
-    assert c.has_option('azure', 'resource_group')
-    assert c.has_option('azure', 'vnet')
-    assert c.has_option('azure', 'vnet_cidr')
-    assert c.has_option('azure', 'subnet')
-    assert c.has_option('azure', 'subnet_cidr')
-    assert c.has_option('azure', 'numnodes')
-    assert c.has_option('azure', 'location')
-    assert c.instance_tags() == {}
-    assert len(c.nodes()) == 6
-    assert c.get_node('leader1') == ['namenode', 'resourcemanager', 'accumulomaster', 'zookeeper']
-    assert c.get_node('leader2') == ['metrics']
-    assert c.get_node('worker1') == ['worker', 'swarmmanager']
-    assert c.get_node('worker2') == ['worker']
-    assert c.get_node('worker3') == ['worker']
-    assert c.has_service('accumulomaster')
-    assert not c.has_service('fluo')
-    assert c.get_service_hostnames('worker') == ['worker1', 'worker2', 'worker3', 'worker4']
-    assert c.get_service_hostnames('zookeeper') == ['leader1']
-    assert c.get_hosts() == {'leader2': ('10.0.0.1', None), 'leader1': ('10.0.0.0', '23.0.0.0'),
-                             'worker1': ('10.0.0.2', None), 'worker3': ('10.0.0.4', None),
-                             'worker2': ('10.0.0.3', None), 'worker4': ('10.0.0.5', None)}
-    assert c.get_public_ip('leader1') == '23.0.0.0'
-    assert c.get_private_ip('leader1') == '10.0.0.0'
-    assert c.cluster_name == 'mycluster'
-    assert c.get_cluster_type() == 'azure'
-    assert c.version("accumulo").startswith('2.')
-    assert c.version("fluo").startswith('1.')
-    assert c.version("hadoop").startswith('3.')
-    assert c.version("zookeeper").startswith('3.')
-    assert c.get_service_private_ips("worker") == ['10.0.0.2', '10.0.0.3', '10.0.0.4', '10.0.0.5']
-    assert c.get('general', 'proxy_hostname') == "leader1"
-    assert c.proxy_public_ip() == "23.0.0.0"
-    assert c.proxy_private_ip() == "10.0.0.0"
-    assert c.get('general', 'cluster_user') == "centos"
-    assert c.get('general', 'cluster_group') == "centos"
-    assert c.get_non_proxy() == [('10.0.0.1', 'leader2'), ('10.0.0.2', 'worker1'), ('10.0.0.3', 'worker2'),
-                                 ('10.0.0.4', 'worker3'), ('10.0.0.5', 'worker4')]
-    assert c.get_host_services() == [('leader1', 'namenode resourcemanager accumulomaster zookeeper'),
-                                     ('leader2', 'metrics'),
-                                     ('worker1', 'worker swarmmanager'),
-                                     ('worker2', 'worker'),
-                                     ('worker3', 'worker'),
-                                     ('worker4', 'worker')]
-
-
-def test_existing_cluster():
-    c = ExistingDeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
-                     '../conf/checksums', '../conf/templates', 'mycluster')
-    c.cluster_type = 'existing'
-    assert c.get_cluster_type() == 'existing'
-    assert c.node_type_map() == {}
-    assert c.mount_root() == '/var/data'
-    assert c.fstype() is None
-    assert c.force_format() == 'no'
-    assert c.worker_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
-    assert c.default_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
-    assert c.metrics_drive_ids() == ['var-data1', 'var-data2', 'var-data3']
-    assert c.shutdown_delay_minutes() == '0'
 
 
 def test_case_sensitive():

--- a/lib/tests/existing/__init__.py
+++ b/lib/tests/existing/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+

--- a/lib/tests/existing/test_config.py
+++ b/lib/tests/existing/test_config.py
@@ -25,8 +25,6 @@ def test_existing_cluster():
     assert c.get_cluster_type() == 'existing'
     assert c.node_type_map() == {}
     assert c.mount_root() == '/var/data'
-    assert c.fstype() is None
-    assert c.force_format() == 'no'
     assert c.worker_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
     assert c.default_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
     assert c.metrics_drive_ids() == ['var-data1', 'var-data2', 'var-data3']

--- a/lib/tests/existing/test_config.py
+++ b/lib/tests/existing/test_config.py
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from muchos.config import ExistingDeployConfig
+
+
+def test_existing_cluster():
+    c = ExistingDeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
+                     '../conf/checksums', '../conf/templates', 'mycluster')
+    c.cluster_type = 'existing'
+    assert c.get_cluster_type() == 'existing'
+    assert c.node_type_map() == {}
+    assert c.mount_root() == '/var/data'
+    assert c.fstype() is None
+    assert c.force_format() == 'no'
+    assert c.worker_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
+    assert c.default_data_dirs() == ['/var/data1', '/var/data2', '/var/data3']
+    assert c.metrics_drive_ids() == ['var-data1', 'var-data2', 'var-data3']
+    assert c.shutdown_delay_minutes() == '0'

--- a/lib/tests/test_config.py
+++ b/lib/tests/test_config.py
@@ -15,11 +15,11 @@
 # limitations under the License.
 #
 
-from muchos.config import DeployConfig
+from muchos.config import DeployConfig, ExistingDeployConfig, Ec2DeployConfig, AzureDeployConfig
 
 
 def test_ec2_cluster():
-    c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
+    c = Ec2DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
                      '../conf/checksums', '../conf/templates', 'mycluster')
     assert c.checksum_ver('accumulo', '1.9.0') == 'f68a6145029a9ea843b0305c90a7f5f0334d8a8ceeea94734267ec36421fe7fe'
     assert c.checksum('accumulo') == 'df172111698c7a73aa031de09bd5589263a6b824482fbb9b4f0440a16602ed47'
@@ -82,7 +82,7 @@ def test_ec2_cluster():
 
 
 def test_azure_cluster():
-    c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
+    c = AzureDeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
                      '../conf/checksums', '../conf/templates', 'mycluster')
 
     # since we are sharing a single muchos.props.example file, we need
@@ -150,7 +150,7 @@ def test_azure_cluster():
 
 
 def test_existing_cluster():
-    c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
+    c = ExistingDeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
                      '../conf/checksums', '../conf/templates', 'mycluster')
     c.cluster_type = 'existing'
     assert c.get_cluster_type() == 'existing'
@@ -165,7 +165,7 @@ def test_existing_cluster():
 
 
 def test_case_sensitive():
-    c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
+    c = Ec2DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
                      '../conf/checksums', '../conf/templates', 'mycluster')
     assert c.has_option('ec2', 'default_instance_type') == True
     assert c.has_option('ec2', 'Default_instance_type') == False
@@ -175,7 +175,7 @@ def test_case_sensitive():
 
 
 def test_ec2_cluster_template():
-    c = DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
+    c = Ec2DeployConfig("muchos", '../conf/muchos.props.example', '../conf/hosts/example/example_cluster',
                      '../conf/checksums', '../conf/templates', 'mycluster')
 
     c.set('ec2', 'cluster_template', 'example')


### PR DESCRIPTION
This is a refactor of config.py to model the difference in configurations based on the cluster type [existing, ec2, azure] by creating an object hierarchy for the configs with shared facilities/attributes in the base class and cluster type specific attributes in the cluster specific implementation.

Also adds python decorators to help annotate where the config item(s) should be rendered to, if it needs to be rendered, and removed most of the related logic from muchos/existing.py.

Lastly, split off the test code for each config types in to separate files based on cluster type.

Implements: #285 