### PR TITLE
Fix Muchos to work with Java 11

### DIFF
--- a/ansible/roles/hadoop/tasks/main.yml
+++ b/ansible/roles/hadoop/tasks/main.yml
@@ -34,6 +34,12 @@
   with_items:
     - workers
   when: hadoop_major_version == '3'
+
+# This is currently needed to run hadoop with Java 11 (see https://github.com/apache/fluo-muchos/issues/266)
+- name: "Copy javax.activation-api (when Hadoop 3 and Java 11 are used)"
+  synchronize: src={{ user_home }}/mvn_dep/ dest={{ hadoop_home }}/share/hadoop/common/lib/
+  when: hadoop_major_version == '3' and java_product_version == 11
+
 - name: "copy spark yarn shuffle jar to hadoop lib"
   command: cp {{ spark_home }}/yarn/spark-{{ spark_version }}-yarn-shuffle.jar {{ hadoop_home }}/share/hadoop/yarn/lib/ creates={{ hadoop_home }}/share/hadoop/yarn/lib/spark-{{ spark_version }}-yarn-shuffle.jar
   when: "'spark' in groups"

--- a/ansible/roles/proxy/tasks/download.yml
+++ b/ansible/roles/proxy/tasks/download.yml
@@ -32,3 +32,13 @@
     - { urlp: "{{ apache_mirror.stdout }}/hadoop/common/hadoop-{{ hadoop_version }}", fn: "{{ hadoop_tarball }}", sum: "{{ hadoop_sha256 }}" }
     - { urlp: "{{ apache_mirror.stdout }}/maven/maven-3/{{ maven_version }}/binaries", fn: "{{ maven_tarball }}", sum: "{{ maven_sha256 }}" }
     - { urlp: "https://github.com/github/hub/releases/download/v{{ hub_version }}", fn: "{{ hub_tarball }}", sum: "{{ hub_sha256 }}" }
+
+# This is currently needed to run hadoop with Java 11 (see https://github.com/apache/fluo-muchos/issues/266)      
+- name: "Download javax.activation-api for Hadoop 3 when Java 11 is used"
+  maven_artifact:
+   group_id: javax.activation
+   artifact_id: javax.activation-api
+   version: 1.2.0
+   dest: "{{ user_home }}/mvn_dep/"
+   mode: 0644
+  when: hadoop_major_version == '3' and java_product_version == 11 

--- a/ansible/scripts/install_ansible.sh
+++ b/ansible/scripts/install_ansible.sh
@@ -41,3 +41,6 @@ if [ ! -h /etc/ansible/hosts ]; then
   sudo rm -f hosts
   sudo ln -s $base_dir/conf/hosts hosts
 fi
+
+# install lxml as it is a dependency for the maven_artifact Ansible module
+sudo yum install -q -y python-lxml

--- a/lib/muchos/existing.py
+++ b/lib/muchos/existing.py
@@ -67,6 +67,7 @@ class ExistingCluster:
         play_vars["force_format"] = config.force_format()
         host_vars['worker_data_dirs'] = str(config.worker_data_dirs())
         host_vars['default_data_dirs'] = str(config.default_data_dirs())
+        host_vars['java_product_version'] = str(config.java_product_version())
 
         with open(join(config.deploy_path, "ansible/site.yml"), 'w') as site_file:
             print("- import_playbook: common.yml", file=site_file)


### PR DESCRIPTION
Fixes #266 by downloading the javax-activation-api artifiact to proxy and then copying out to worker nodes.