### PR TITLE
allow using accumulo snapshot with java11

### DIFF
--- a/lib/muchos/config/base.py
+++ b/lib/muchos/config/base.py
@@ -171,7 +171,7 @@ class BaseConfig(ConfigParser, metaclass=ABCMeta):
 
             # validate if we are using Java 11 and fail if we are using Accumulo 1.x
             # See https://github.com/apache/accumulo/issues/958 for details
-            if self.java_product_version() >= 11 and StrictVersion(self.version('accumulo')) <= StrictVersion("1.9.3"):
+            if self.java_product_version() >= 11 and StrictVersion(self.version('accumulo').replace('-SNAPSHOT','')) <= StrictVersion("1.9.3"):
                 exit("ERROR - Java 11 is not supported with Accumulo version '{0}'".format(self.version('accumulo')))
 
     @abstractmethod


### PR DESCRIPTION
Saw the following error when attempting to use snapshot version of
Accumulo and Java 11.  This commit fixes there error.

```
$ ./bin/muchos launch -c kt1
Traceback (most recent call last):
  File "/home/user1/muchos/lib/main.py", line 83, in <module>
    main()
  File "/home/user1/muchos/lib/main.py", line 55, in main
    config.verify_config(action)
  File "/home/user1/muchos/lib/muchos/config/ec2.py", line 40, in
verify_config
    self._verify_config(action)
  File "/home/user1/muchos/lib/muchos/config/base.py", line 174, in
_verify_config
    if self.java_product_version() >= 11 and
StrictVersion(self.version('accumulo')) <= StrictVersion("1.9.3"):
  File "/usr/lib/python3.5/distutils/version.py", line 40, in __init__
    self.parse(vstring)
  File "/usr/lib/python3.5/distutils/version.py", line 137, in parse
    raise ValueError("invalid version number '%s'" % vstring)
ValueError: invalid version number '2.1.0-SNAPSHOT'
```