### PR TITLE
Apply #266 fix to Hadoop HA role

### DIFF
--- a/ansible/roles/hadoop-ha/tasks/main.yml
+++ b/ansible/roles/hadoop-ha/tasks/main.yml
@@ -24,6 +24,7 @@
     - hdfs-site.xml
     - yarn-site.xml
     - mapred-site.xml
+    - hadoop-metrics2.properties
 - name: "configure hadoop 2"
   template: src={{ item }} dest={{ hadoop_home }}/etc/hadoop/{{ item }}
   with_items:
@@ -34,6 +35,12 @@
   with_items:
     - workers
   when: hadoop_major_version == '3'
+
+# This is currently needed to run hadoop with Java 11 (see https://github.com/apache/fluo-muchos/issues/266)
+- name: "Copy javax.activation-api (when Hadoop 3 and Java 11 are used)"
+  synchronize: src={{ user_home }}/mvn_dep/ dest={{ hadoop_home }}/share/hadoop/common/lib/
+  when: hadoop_major_version == '3' and java_product_version == 11
+
 - name: "copy spark yarn shuffle jar to hadoop lib"
   command: cp {{ spark_home }}/yarn/spark-{{ spark_version }}-yarn-shuffle.jar {{ hadoop_home }}/share/hadoop/yarn/lib/ creates={{ hadoop_home }}/share/hadoop/yarn/lib/spark-{{ spark_version }}-yarn-shuffle.jar
   when: "'spark' in groups"


### PR DESCRIPTION
Fix for #266 was already applied to `hadoop` role. This PR extends the same fix to `hadoop-ha` role,  introduced in #284 
Along with this fix, I have also included the missing `hadoop-metrics2.properties` to `hadoop-ha` role. Let me know if this needs a separate PR? 
Many thanks,