### PR TITLE
Retry fetching the ASF mirror list

### DIFF
--- a/ansible/roles/accumulo/tasks/download.yml
+++ b/ansible/roles/accumulo/tasks/download.yml
@@ -19,6 +19,8 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  retries: 10
+  delay: 10
   register: apache_mirror
   failed_when: "'http' not in apache_mirror.stdout"
   changed_when: False

--- a/ansible/roles/fluo/tasks/download.yml
+++ b/ansible/roles/fluo/tasks/download.yml
@@ -19,6 +19,8 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  retries: 10
+  delay: 10
   register: apache_mirror
   failed_when: "'http' not in apache_mirror.stdout"
   changed_when: False

--- a/ansible/roles/fluo_yarn/tasks/download.yml
+++ b/ansible/roles/fluo_yarn/tasks/download.yml
@@ -19,6 +19,8 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  retries: 10
+  delay: 10
   register: apache_mirror
   failed_when: "'http' not in apache_mirror.stdout"
   changed_when: False

--- a/ansible/roles/proxy/tasks/download.yml
+++ b/ansible/roles/proxy/tasks/download.yml
@@ -19,6 +19,8 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  retries: 10
+  delay: 10
   register: apache_mirror
   failed_when: "'http' not in apache_mirror.stdout"
   changed_when: False

--- a/ansible/roles/spark/tasks/download.yml
+++ b/ansible/roles/spark/tasks/download.yml
@@ -19,6 +19,8 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  retries: 10
+  delay: 10
   register: apache_mirror
   failed_when: "'http' not in apache_mirror.stdout"
   changed_when: False


### PR DESCRIPTION
Sometimes due to transient issues at the ASF Infra end, the enumeration
of Apache mirrors has been found to return a blank response. Retries
help mitigate this issue.