### PR TITLE
Include 'hadoop-metrics2.properties' file for Hadoop HA roles

### DIFF
--- a/ansible/roles/hadoop-ha/templates/hadoop-metrics2.properties
+++ b/ansible/roles/hadoop-ha/templates/hadoop-metrics2.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{% if cluster_type == 'azure' %}
+*.sink.statsd.class=org.apache.hadoop.metrics2.sink.StatsDSink
+*.sink.statsd.period=60
+namenode.sink.statsd.server.host=127.0.0.1
+namenode.sink.statsd.server.port=8125
+namenode.sink.statsd.skip.hostname=true
+namenode.sink.statsd.service.name=NameNode
+datanode.sink.statsd.server.host=127.0.0.1
+datanode.sink.statsd.server.port=8125
+datanode.sink.statsd.skip.hostname=true
+datanode.sink.statsd.service.name=DataNode
+{% endif %}


### PR DESCRIPTION
Fix the missing `hadoop-metrics2.properties` file under Hadoop HA templates

