### PR TITLE
Update maven url to use 'https' instead of 'http'

### DIFF
--- a/ansible/roles/proxy/tasks/download.yml
+++ b/ansible/roles/proxy/tasks/download.yml
@@ -40,6 +40,7 @@
   maven_artifact:
    group_id: javax.activation
    artifact_id: javax.activation-api
+   repository_url: 'https://repo.maven.apache.org/maven2/'
    version: 1.2.0
    dest: "{{ user_home }}/mvn_dep/"
    mode: 0644


### PR DESCRIPTION
Submitting the PR for maven url to use 'https' instead of 'http', this is due to the recent implementation of SSL in maven for clients accessing the repository. 