### PR TITLE
Correctly retry ASF mirror listing task

### DIFF
--- a/ansible/roles/accumulo/tasks/download.yml
+++ b/ansible/roles/accumulo/tasks/download.yml
@@ -19,10 +19,10 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  register: apache_mirror
   retries: 10
   delay: 10
-  register: apache_mirror
-  failed_when: "'http' not in apache_mirror.stdout"
+  until: "'http' in apache_mirror.stdout"
   changed_when: False
 - name: "check if Accumulo tarball was uploaded to proxy"
   stat: path={{ tarballs_dir }}/{{ accumulo_tarball }}

--- a/ansible/roles/accumulo/tasks/download.yml
+++ b/ansible/roles/accumulo/tasks/download.yml
@@ -15,15 +15,7 @@
 # limitations under the License.
 #
 
-- name: "determine best apache mirror to use"
-  shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
-  args:
-    warn: no
-  register: apache_mirror
-  retries: 10
-  delay: 10
-  until: "'http' in apache_mirror.stdout"
-  changed_when: False
+- import_tasks: ../../proxy/tasks/get-asf-mirror.yml
 - name: "check if Accumulo tarball was uploaded to proxy"
   stat: path={{ tarballs_dir }}/{{ accumulo_tarball }}
   register: accumulo

--- a/ansible/roles/fluo/tasks/download.yml
+++ b/ansible/roles/fluo/tasks/download.yml
@@ -15,15 +15,7 @@
 # limitations under the License.
 #
 
-- name: "determine best apache mirror to use"
-  shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
-  args:
-    warn: no
-  register: apache_mirror
-  retries: 10
-  delay: 10
-  until: "'http' in apache_mirror.stdout"
-  changed_when: False
+- import_tasks: ../../proxy/tasks/get-asf-mirror.yml
 - name: "check if Fluo tarball was uploaded to proxy"
   stat: path={{ tarballs_dir }}/{{ fluo_tarball }}
   register: fluo

--- a/ansible/roles/fluo/tasks/download.yml
+++ b/ansible/roles/fluo/tasks/download.yml
@@ -19,10 +19,10 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  register: apache_mirror
   retries: 10
   delay: 10
-  register: apache_mirror
-  failed_when: "'http' not in apache_mirror.stdout"
+  until: "'http' in apache_mirror.stdout"
   changed_when: False
 - name: "check if Fluo tarball was uploaded to proxy"
   stat: path={{ tarballs_dir }}/{{ fluo_tarball }}

--- a/ansible/roles/fluo_yarn/tasks/download.yml
+++ b/ansible/roles/fluo_yarn/tasks/download.yml
@@ -15,15 +15,7 @@
 # limitations under the License.
 #
 
-- name: "determine best apache mirror to use"
-  shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
-  args:
-    warn: no
-  register: apache_mirror
-  retries: 10
-  delay: 10
-  until: "'http' in apache_mirror.stdout"
-  changed_when: False
+- import_tasks: ../../proxy/tasks/get-asf-mirror.yml
 - name: "check if Fluo YARN tarball was uploaded to proxy"
   stat: path={{ tarballs_dir }}/{{ fluo_yarn_tarball }}
   register: fluo_yarn

--- a/ansible/roles/fluo_yarn/tasks/download.yml
+++ b/ansible/roles/fluo_yarn/tasks/download.yml
@@ -19,10 +19,10 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  register: apache_mirror
   retries: 10
   delay: 10
-  register: apache_mirror
-  failed_when: "'http' not in apache_mirror.stdout"
+  until: "'http' in apache_mirror.stdout"
   changed_when: False
 - name: "check if Fluo YARN tarball was uploaded to proxy"
   stat: path={{ tarballs_dir }}/{{ fluo_yarn_tarball }}

--- a/ansible/roles/proxy/tasks/download.yml
+++ b/ansible/roles/proxy/tasks/download.yml
@@ -15,15 +15,7 @@
 # limitations under the License.
 #
 
-- name: "determine best apache mirror to use"
-  shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
-  args:
-    warn: no
-  register: apache_mirror
-  retries: 10
-  delay: 10
-  until: "'http' in apache_mirror.stdout"
-  changed_when: False
+- import_tasks: get-asf-mirror.yml
 - name: "download common tarballs to proxy"
   get_url: url={{ item.urlp }}/{{ item.fn }} dest={{ tarballs_dir }}/{{ item.fn }} checksum="{{ item.sum }}" force=no
   register: gresult

--- a/ansible/roles/proxy/tasks/download.yml
+++ b/ansible/roles/proxy/tasks/download.yml
@@ -19,10 +19,10 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  register: apache_mirror
   retries: 10
   delay: 10
-  register: apache_mirror
-  failed_when: "'http' not in apache_mirror.stdout"
+  until: "'http' in apache_mirror.stdout"
   changed_when: False
 - name: "download common tarballs to proxy"
   get_url: url={{ item.urlp }}/{{ item.fn }} dest={{ tarballs_dir }}/{{ item.fn }} checksum="{{ item.sum }}" force=no

--- a/ansible/roles/proxy/tasks/get-asf-mirror.yml
+++ b/ansible/roles/proxy/tasks/get-asf-mirror.yml
@@ -1,0 +1,9 @@
+- name: "determine best apache mirror to use"
+  shell: curl -sk https://apache.org/mirrors.cgi?as_json | jq -r .preferred
+  args:
+    warn: no
+  register: apache_mirror
+  retries: 10
+  delay: 10
+  until: "apache_mirror.stdout | length > 0"
+  changed_when: False

--- a/ansible/roles/proxy/tasks/get-asf-mirror.yml
+++ b/ansible/roles/proxy/tasks/get-asf-mirror.yml
@@ -1,5 +1,5 @@
 - name: "determine best apache mirror to use"
-  shell: curl -sk https://apache.org/mirrors.cgi?as_json | jq -r .preferred
+  shell: curl -sk https://www.apache.org/dyn/closer.cgi?as_json | jq -r .preferred
   args:
     warn: no
   register: apache_mirror

--- a/ansible/roles/spark/tasks/download.yml
+++ b/ansible/roles/spark/tasks/download.yml
@@ -15,15 +15,7 @@
 # limitations under the License.
 #
 
-- name: "determine best apache mirror to use"
-  shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
-  args:
-    warn: no
-  register: apache_mirror
-  retries: 10
-  delay: 10
-  until: "'http' in apache_mirror.stdout"
-  changed_when: False
+- import_tasks: ../../proxy/tasks/get-asf-mirror.yml
 - name: "check if Spark tarball was uploaded to proxy"
   stat: path={{ tarballs_dir }}/{{ spark_tarball }}
   register: spark

--- a/ansible/roles/spark/tasks/download.yml
+++ b/ansible/roles/spark/tasks/download.yml
@@ -19,10 +19,10 @@
   shell: curl -sk https://apache.org/mirrors.cgi?as_json | grep preferred | cut -d \" -f 4
   args:
     warn: no
+  register: apache_mirror
   retries: 10
   delay: 10
-  register: apache_mirror
-  failed_when: "'http' not in apache_mirror.stdout"
+  until: "'http' in apache_mirror.stdout"
   changed_when: False
 - name: "check if Spark tarball was uploaded to proxy"
   stat: path={{ tarballs_dir }}/{{ spark_tarball }}

--- a/ansible/scripts/install_ansible.sh
+++ b/ansible/scripts/install_ansible.sh
@@ -48,3 +48,6 @@ fi
 
 # install lxml as it is a dependency for the maven_artifact Ansible module
 sudo yum install -q -y python-lxml
+
+# install jq to ease JSON parsing on the proxy
+sudo yum install -y jq


### PR DESCRIPTION
The previous addition of retry was ineffective because it had a
failed_when condition - which needs to be an 'until' condition to
correctly detect success.