### PR TITLE
Correctly handle @default decorator for boolean

### DIFF
--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -107,9 +107,10 @@ class AzureDeployConfig(BaseConfig):
         return self.get('azure', 'az_logs_key')
 
     @ansible_host_var(name='use_adlsg2')
-    @default(None)
+    @is_valid(is_in([True, False]))
+    @default(False)
     def use_adlsg2(self):
-        return self.get('azure', 'use_adlsg2')
+        return self.getboolean('azure', 'use_adlsg2')
 
     @ansible_host_var(name='azure_tenant_id')
     @default(None)

--- a/lib/muchos/config/decorators.py
+++ b/lib/muchos/config/decorators.py
@@ -74,7 +74,7 @@ def default(val):
             except:
                 return val
             else:
-                if res in [None, 0, ''] or isinstance(res, str) and len(res) == 0:
+                if res is None or (isinstance(res, str) and len(res) == 0):
                     return val
                 return res
         return wrapper


### PR DESCRIPTION
Fixes a bug in the handling of defaults within the Python decorator code
wherein any boolean parameter with value False would be wrongly assigned 
the default value. Correspondingly also fixes the type of use_adlsg2 to boolean.