### PR TITLE
Add stat 4lw for zookeeper

### DIFF
--- a/ansible/roles/zookeeper/templates/zoo.cfg
+++ b/ansible/roles/zookeeper/templates/zoo.cfg
@@ -16,7 +16,7 @@ clientPort={{ zookeeper_client_port }}
 # increase this if you need to handle more clients
 maxClientCnxns=100
 # support zk monitoring (for zk >= 3.5)
-{% if zookeeper_version.startswith('3.5') %}
+{% if zookeeper_version is version('3.5', '>=') %}
 4lw.commands.whitelist=mntr,stat
 {% endif %}
 {% for host in groups['zookeepers'] %}

--- a/ansible/roles/zookeeper/templates/zoo.cfg
+++ b/ansible/roles/zookeeper/templates/zoo.cfg
@@ -16,7 +16,9 @@ clientPort={{ zookeeper_client_port }}
 # increase this if you need to handle more clients
 maxClientCnxns=100
 # support zk monitoring (for zk >= 3.5)
-4lw.commands.whitelist=mntr
+{% if zookeeper_version.startswith('3.5') %}
+4lw.commands.whitelist=mntr,stat
+{% endif %}
 {% for host in groups['zookeepers'] %}
 server.{{ loop.index }}={{ host }}:2888:3888
 {% endfor %}

--- a/lib/muchos/config/base.py
+++ b/lib/muchos/config/base.py
@@ -73,7 +73,7 @@ _HOST_VAR_DEFAULTS = {
   'worker_data_dirs': None,
   'zookeeper_connect': "{% for host in groups['zookeepers'] %}{{ host }}:2181{% if not loop.last %},{% endif %}{% endfor %}",
   'zookeeper_client_port': '"2181"',
-  'zookeeper_basename': "{% if zookeeper_version.startswith('3.5') %}apache-zookeeper-{{ zookeeper_version }}-bin{% else %}zookeeper-{{ zookeeper_version }}{% endif %}",
+  'zookeeper_basename': "{% if zookeeper_version is version('3.5', '>=') %}apache-zookeeper-{{ zookeeper_version }}-bin{% else %}zookeeper-{{ zookeeper_version }}{% endif %}",
   'zookeeper_home': "{{ install_dir }}/{{ zookeeper_basename }}",
   'zookeeper_tarball': "{{ zookeeper_basename }}.tar.gz",
   'zookeeper_version': None


### PR DESCRIPTION
@arvindshmicrosoft observed that the stat four letter word is used by the Accumulo monitor. Also, the 4lw.commands.whitelist property for ZooKeeper has been backported to 3.4.10 with a more permissive default (see https://issues.apache.org/jira/browse/ZOOKEEPER-2693), so we were inadvertently disabling a lot of four letter words that are enabled by default in 3.4. In 3.5, the AdminServer provides an alternative for retrieving the same information, so the four letter words can be disabled.