### PR TITLE
Configure Job history server

### DIFF
--- a/ansible/hadoop.yml
+++ b/ansible/hadoop.yml
@@ -46,3 +46,4 @@
 - hosts: resourcemanager
   tasks:
     - import_tasks: roles/hadoop/tasks/start-yarn.yml
+    - import_tasks: roles/hadoop/tasks/start-jhs.yml

--- a/ansible/roles/hadoop/tasks/start-jhs.yml
+++ b/ansible/roles/hadoop/tasks/start-jhs.yml
@@ -15,17 +15,16 @@
 # limitations under the License.
 #
 
-- name: "ensure zookeeper data dir exists"
-  file: path={{ default_data_dirs[0] }}/zookeeper state=directory
-- name: "ensure myid file is set"
-  template: src=roles/zookeeper/templates/myid dest={{ default_data_dirs[0] }}/zookeeper/myid
-- name: Check if Zookeeper is running
-  shell: jps | grep "QuorumPeerMain" | grep -v grep
+- name: Check if JobHistoryServer is running
+  shell: jps | grep "JobHistoryServer" | grep -v grep
   ignore_errors: yes
   changed_when: false
-  register: zookeeper_status
-- name: "start zookeeper"
-  shell: "{{ zookeeper_home }}/bin/zkServer.sh start"
-  register: zk_start
-  changed_when: "'STARTED' in zk_start.stdout"
-  when: zookeeper_status.rc == 1
+  register: jhs_status
+
+- name: Start Job History Server on Hadoop 3.x
+  command: "nohup {{ hadoop_home }}/bin/mapred --daemon start historyserver"
+  when: jhs_status.rc == 1 and hadoop_major_version == '3'
+
+- name: Start Job History Server on Hadoop 2.x
+  command: "nohup {{ hadoop_home }}/sbin/mr-jobhistory-daemon.sh start historyserver"
+  when: jhs_status.rc == 1 and hadoop_major_version == '2'

--- a/ansible/roles/hadoop/tasks/start-jhs.yml
+++ b/ansible/roles/hadoop/tasks/start-jhs.yml
@@ -16,7 +16,7 @@
 #
 
 - name: Check if JobHistoryServer is running
-  shell: jps | grep "JobHistoryServer" | grep -v grep
+  shell: jps | grep "JobHistoryServer" 
   ignore_errors: yes
   changed_when: false
   register: jhs_status

--- a/ansible/roles/hadoop/templates/mapred-site.xml
+++ b/ansible/roles/hadoop/templates/mapred-site.xml
@@ -60,4 +60,36 @@
     <value>$HADOOP_MAPRED_HOME/share/hadoop/mapreduce/*,$HADOOP_MAPRED_HOME/share/hadoop/mapreduce/lib/*,$HADOOP_MAPRED_HOME/share/hadoop/common/*,$HADOOP_MAPRED_HOME/share/hadoop/common/lib/*,$HADOOP_MAPRED_HOME/share/hadoop/yarn/*,$HADOOP_MAPRED_HOME/share/hadoop/yarn/lib/*,$HADOOP_MAPRED_HOME/share/hadoop/hdfs/*,$HADOOP_MAPRED_HOME/share/hadoop/hdfs/lib/*,$HADOOP_MAPRED_HOME/share/hadoop/tools/lib/*,${HADOOP_HOME}/share/hadoop/client/*</value>
   </property>
 {% endif %}
+  <property>
+    <name>mapreduce.jobhistory.address</name>
+    <value>{{ groups['resourcemanager'][0] }}:10020</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.webapp.address</name>
+    <value>{{ groups['resourcemanager'][0] }}:19888</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.done-dir</name>
+    <value>/mr-history/done</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.http.policy</name>
+    <value>HTTP_ONLY</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.intermediate-done-dir</name>
+    <value>/mr-history/tmp</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.recovery.enable</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.recovery.store.class</name>
+    <value>org.apache.hadoop.mapreduce.v2.hs.HistoryServerLeveldbStateStoreService</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.recovery.store.leveldb.path</name>
+    <value>{{ worker_data_dirs[0] }}/hadoop/mapreduce/jhs</value>
+  </property>  
 </configuration>

--- a/ansible/roles/hadoop/templates/yarn-site.xml
+++ b/ansible/roles/hadoop/templates/yarn-site.xml
@@ -86,4 +86,52 @@
     <value>${HADOOP_HOME}/share/hadoop/tools/lib/*,${HADOOP_HOME}/share/hadoop/hdfs/lib/*,${HADOOP_HOME}/share/hadoop/common/lib/*,${HADOOP_HOME}/share/hadoop/yarn/*,${HADOOP_HOME}/share/hadoop/yarn/lib/*,${HADOOP_HOME}/share/hadoop/hdfs/*,${HADOOP_HOME}/share/hadoop/common/*,${HADOOP_HOME}/share/hadoop/mapreduce/*,${HADOOP_HOME}/share/hadoop/mapreduce/lib/*,${HADOOP_HOME}/share/hadoop/client/*</value>
   </property>
   {% endif %}
+  <property>
+    <name>yarn.resourcemanager.webapp.address</name>
+    <value>{{ groups['resourcemanager'][0] }}:8088</value>
+  </property>
+  <property>
+    <name>yarn.log.server.url</name>
+    <value>http://{{ groups['resourcemanager'][0] }}:19888/jobhistory/logs</value>
+  </property>
+  <property>
+    <name>yarn.log-aggregation-enable</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>yarn.log-aggregation.retain-seconds</name>
+    <value>2592000</value>
+  </property>
+  <property>
+    <name>yarn.log.server.web-service.url</name>
+    <value>http://{{ groups['resourcemanager'][0] }}:8188/ws/v1/applicationhistory</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.log-aggregation.compression-type</name>
+    <value>gz</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.log-aggregation.debug-enabled</name>
+    <value>false</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.log-aggregation.num-log-files-per-app</name>
+    <value>30</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.log-aggregation.roll-monitoring-interval-seconds</name>
+    <value>3600</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.log.retain-seconds</name>
+    <value>604800</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.remote-app-log-dir</name>
+    <value>/app-logs</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.remote-app-log-dir-suffix</name>
+    <value>logs</value>
+  </property>
 </configuration>

--- a/ansible/roles/zookeeper/tasks/start-zookeeper.yml
+++ b/ansible/roles/zookeeper/tasks/start-zookeeper.yml
@@ -20,7 +20,7 @@
 - name: "ensure myid file is set"
   template: src=roles/zookeeper/templates/myid dest={{ default_data_dirs[0] }}/zookeeper/myid
 - name: Check if Zookeeper is running
-  shell: jps | grep "QuorumPeerMain" | grep -v grep
+  shell: jps | grep "QuorumPeerMain" 
   ignore_errors: yes
   changed_when: false
   register: zookeeper_status


### PR DESCRIPTION
In this PR, I have configured Job history server. This is useful during troubleshooting Map-Reduce jobs when testing Accumulo. Also, enabled YARN log aggregation. 
Whilst testing these changes, I noticed Zookeeper missing the idempotent check hence included along with the above changes. Let me know for any comments? Thanks!