### PR TITLE
Added support for Red Hat OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 /.idea/
 /pom.xml
+/.vscode

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -15,12 +15,25 @@
 # limitations under the License.
 #
 
-- name: "enable epel yum repo"
-  yum: name=epel-release state=present
-  register: epelresult
-  retries: 10
-  delay: 15
-  until: epelresult is not failed
+- name: "enable epel yum repo (Red Hat)"
+  block:
+    - name: "check if epel is installed"
+      shell: "rpm -q --quiet epel-release"
+      register: epel_installed
+      failed_when: epel_installed.rc == 2
+    - name: "install epel on Red Hat"
+      shell: "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+      when: epel_installed.rc == 1
+  when: ansible_distribution == "RedHat"
+- name: "enable epel yum repo (CentOS)"
+  block:
+    - name: "enable epel yum repo (CentOS)"
+      yum: name=epel-release state=present
+      register: epelresult
+      retries: 10
+      delay: 15
+      until: epelresult is not failed
+  when: ansible_distribution == "CentOS"
 - name: "install packages"
   yum:
     name:
@@ -39,6 +52,16 @@
   retries: 10
   delay: 15
   until: yumresult is not failed
+- name: "enable SELinux (Red Hat)"
+  block:
+    - name: "check if container-selinux is installed"
+      shell: "rpm -q --quiet container-selinux"
+      register: container_selinux_installed
+      failed_when: container_selinux_installed.rc == 2
+    - name: "install container-selinux"
+      shell: "sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm"
+      when: container_selinux_installed.rc == 1
+  when: ansible_distribution == "RedHat"
 - name: "configure node shutdown"
   shell: shutdown +{{ shutdown_delay_minutes }} &> {{ user_home }}/.shutdown creates={{ user_home }}/.shutdown
   when: shutdown_delay_minutes > 0

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -59,6 +59,7 @@
       register: container_selinux_installed
       failed_when: container_selinux_installed.rc == 2
     - name: "install container-selinux"
+      # This makes docker work on RHEL 7
       shell: "sudo yum -y install http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.107-1.el7_6.noarch.rpm"
       when: container_selinux_installed.rc == 1
   when: ansible_distribution == "RedHat"

--- a/ansible/scripts/install_ansible.sh
+++ b/ansible/scripts/install_ansible.sh
@@ -22,9 +22,19 @@ base_dir=$( cd "$( dirname "$bin" )" && pwd )
 
 set -e
 
+# get the release id
+if [ -f /etc/os-release ]; then
+  . /etc/os-release
+  ID=$ID
+fi
+
 # enable yum epel repo
-is_installed_epel_release="rpm -q --quiet epel-release"
-install_epel_release="sudo yum install -q -y epel-release"
+if [ $ID = "rhel" ]; then
+  is_installed_epel_release="rpm -q --quiet epel-release"
+else
+  install_epel_release="sudo yum install -q -y epel-release"
+fi
+install_epel_release="sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 for i in {1..10}; do ($is_installed_epel_release || $install_epel_release) && break || sleep 15; done
 
 # install ansible
@@ -47,7 +57,11 @@ if [ ! -h /etc/ansible/hosts ]; then
 fi
 
 # install lxml as it is a dependency for the maven_artifact Ansible module
-sudo yum install -q -y python-lxml
+if [ $ID = "rhel" ]; then
+  sudo yum install -q -y python3-lxml
+else
+  sudo yum install -q -y python-lxml
+fi
 
 # install jq to ease JSON parsing on the proxy
 sudo yum install -y jq

--- a/ansible/scripts/install_ansible.sh
+++ b/ansible/scripts/install_ansible.sh
@@ -30,11 +30,11 @@ fi
 
 # enable yum epel repo
 if [ $ID = "rhel" ]; then
-  is_installed_epel_release="rpm -q --quiet epel-release"
+  install_epel_release="sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 else
   install_epel_release="sudo yum install -q -y epel-release"
 fi
-install_epel_release="sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+ is_installed_epel_release="rpm -q --quiet epel-release"
 for i in {1..10}; do ($is_installed_epel_release || $install_epel_release) && break || sleep 15; done
 
 # install ansible


### PR DESCRIPTION
This PR adds support for RHEL as a base OS instead of CentOS. No configuration changes are needed as the ansible and and `install_ansible.sh` scripts will autodetect the distribution and run the necessary steps.