### PR TITLE
Adds systemd support for accumulo services

### DIFF
--- a/ansible/accumulo.yml
+++ b/ansible/accumulo.yml
@@ -43,14 +43,14 @@
       command: "{{ accumulo_home }}/bin/start-here.sh"
       register: start_result
       changed_when: "'Starting' in start_result.stdout"
-      when: accumulo_major_version == '1'
+      when: accumulo_major_version == '1' and use_systemd == False
 - hosts: workers
   tasks:
     - name: "start accumulo 2.0 tablet servers"
       command: "nohup {{ accumulo_home }}/bin/accumulo-service tserver start"
       register: start_result
       changed_when: "'Starting' in start_result.stdout"
-      when: accumulo_major_version == '2'
+      when: accumulo_major_version == '2' and use_systemd == False
 - hosts: accumulomaster
   tasks:
     - name: "start accumulo 2.0 master, monitor, gc & tracer"
@@ -62,4 +62,21 @@
         - monitor
         - gc
         - tracer
-      when: accumulo_major_version == '2'
+      when: accumulo_major_version == '2' and use_systemd == False
+- hosts: accumulomaster
+  tasks:
+    - name: "install and start all the accumulo services using systemd"
+      block:
+        - import_tasks: roles/accumulo/tasks/start-master.yml
+        - import_tasks: roles/accumulo/tasks/start-gc.yml
+        - import_tasks: roles/accumulo/tasks/start-monitor.yml
+        - import_tasks: roles/accumulo/tasks/start-tracer.yml
+      when: use_systemd == True
+      become: yes
+      
+- hosts: workers
+  gather_facts: false
+  tasks:
+    - import_tasks: roles/accumulo/tasks/start-tserver.yml
+      when: use_systemd == True
+      become: yes

--- a/ansible/roles/accumulo/files/accumulo-cluster-systemd
+++ b/ansible/roles/accumulo/files/accumulo-cluster-systemd
@@ -109,15 +109,15 @@ function control_tserver_service() {
 
     if [[ $host == "localhost" || $host == $(hostname -f) || $host == $(hostname -s) || $host == $(get_ip) ]]; then
       for (( inst_id=1; inst_id<="${NUM_TSERVERS:-1}"; inst_id++ )); do
-        if systemctl list-units | grep 'accumulo_tserver'; then
-            sudo systemctl "${control_cmd}" accumulo_tserver@"${inst_id}".service
+        if systemctl list-units | grep 'accumulo-tserver'; then
+            sudo systemctl "${control_cmd}" accumulo-tserver@"${inst_id}".service
         fi
       done
     else
       $SSH "$host" /bin/bash <<EOF
       for (( inst_id=1; inst_id<="${NUM_TSERVERS:-1}"; inst_id++ )); do
-        if systemctl list-units | grep 'accumulo_tserver'; then
-            sudo systemctl "${control_cmd}" accumulo_tserver@\${inst_id}.service
+        if systemctl list-units | grep 'accumulo-tserver'; then
+            sudo systemctl "${control_cmd}" accumulo-tserver@\${inst_id}.service
         fi
       done
 EOF
@@ -134,10 +134,10 @@ function start_service() {
   fi
 
   if [[ $host == "localhost" || $host == $(hostname -f) || $host == $(hostname -s) || $host == $(get_ip) ]]; then
-    find /etc/systemd/system/ -type f -name "accumulo_${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl start
+    find /etc/systemd/system/ -type f -name "accumulo-${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl start
   else
     $SSH "$host" /bin/bash <<EOF
-    find /etc/systemd/system/ -type f -name "accumulo_${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl start
+    find /etc/systemd/system/ -type f -name "accumulo-${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl start
 EOF
   fi
 }
@@ -234,10 +234,10 @@ function stop_service() {
   fi
 
   if [[ $host == "localhost" || $host == $(hostname -f) || $host == $(hostname -s) || $host == $(get_ip) ]]; then
-    find /etc/systemd/system/ -type f -name "accumulo_${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl stop
+    find /etc/systemd/system/ -type f -name "accumulo-${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl stop
   else
     $SSH "$host" /bin/bash <<EOF
-    find /etc/systemd/system/ -type f -name "accumulo_${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl stop
+    find /etc/systemd/system/ -type f -name "accumulo-${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl stop
 EOF
   fi
 }

--- a/ansible/roles/accumulo/files/accumulo-cluster-systemd
+++ b/ansible/roles/accumulo/files/accumulo-cluster-systemd
@@ -1,0 +1,382 @@
+#! /usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used when Accumulo services are managed by systemd
+function print_usage {
+  cat <<EOF
+Usage: accumulo-cluster <command> (<argument> ...)
+To run more than 1 tservers per node, run accumulo-cluster
+command with NUM_TSERVERS=n prefix.
+
+For example, to start 2 tservers per node, run the below command.
+NUM_TSERVERS=2 accumulo-cluster start
+
+Commands:
+  create-config       Creates cluster config
+  restart             Restarts the Accumulo cluster
+  start               Starts Accumulo cluster
+  stop                Stops Accumulo cluster
+  start-non-tservers  Starts all services except tservers
+  start-tservers      Starts all tservers on cluster
+  stop-tservers       Stops all tservers on cluster
+  start-here          Starts all services on this node
+  stop-here           Stops all services on this node
+EOF
+  exit 1
+}
+
+function invalid_args {
+  echo -e "Invalid arguments: $1\n"
+  print_usage 1>&2
+  exit 1
+}
+
+function verify_config {
+  if [[ -f ${conf}/slaves ]]; then
+    echo "ERROR: A 'slaves' file was found in ${conf}/"
+    echo "Accumulo now reads tablet server hosts from 'tservers' and requires that the 'slaves' file not be present to reduce confusion."
+    echo "Please rename the 'slaves' file to 'tservers' or remove it if both exist."
+    exit 1
+  fi
+
+  if [[ ! -f ${conf}/tservers ]]; then
+    echo "ERROR: A 'tservers' file was not found at ${conf}/tservers"
+    echo "Please make sure it exists and is configured with tablet server hosts."
+    exit 1
+  fi
+
+
+  unset master1
+  if [[ -f "${conf}/masters" ]]; then
+    master1=$(grep -E -v '(^#|^\s*$)' "${conf}/masters" | head -1)
+  fi
+
+  if [[ ! -f "${conf}/monitor" ]]; then
+    if [[ -z "${master1}" ]] ; then
+      echo "Could not find a master node to use as a default for the monitor role."
+      echo "Either set up \"${conf}/monitor\" or make sure \"${conf}/masters\" is non-empty."
+      exit 1
+    else
+      echo "$master1" > "${conf}/monitor"
+    fi
+  fi
+
+  if [[ ! -f "${conf}/tracers" ]]; then
+    if [[ -z "${master1}" ]] ; then
+      echo "Could not find a master node to use as a default for the tracer role."
+      echo "Either set up \"${conf}/tracers\" or make sure \"${conf}/masters\" is non-empty."
+      exit 1
+    else
+      echo "$master1" > "${conf}/tracers"
+    fi
+  fi
+
+  if [[ ! -f "${conf}/gc" ]]; then
+    if [[ -z "${master1}" ]] ; then
+      echo "Could not infer a GC role. You need to either set up \"${conf}/gc\" or make sure \"${conf}/masters\" is non-empty."
+      exit 1
+    else
+      echo "$master1" > "${conf}/gc"
+    fi
+  fi
+}
+
+function get_ip() {
+  ip_addr=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/')
+  if [[ $? != 0 ]]; then
+    ip_addr=$(getent ahosts "$(hostname -f)" | grep DGRAM | cut -f 1 -d ' ')
+  fi
+  echo "$ip_addr"
+}
+
+function control_tserver_service() {
+  host="$1"
+  control_cmd="$2"
+
+    if [[ $host == "localhost" || $host == $(hostname -f) || $host == $(hostname -s) || $host == $(get_ip) ]]; then
+      for (( inst_id=1; inst_id<="${NUM_TSERVERS:-1}"; inst_id++ )); do
+        if systemctl list-units | grep 'accumulo_tserver'; then
+            sudo systemctl "${control_cmd}" accumulo_tserver@"${inst_id}".service
+        fi
+      done
+    else
+      $SSH "$host" /bin/bash <<EOF
+      for (( inst_id=1; inst_id<="${NUM_TSERVERS:-1}"; inst_id++ )); do
+        if systemctl list-units | grep 'accumulo_tserver'; then
+            sudo systemctl "${control_cmd}" accumulo_tserver@\${inst_id}.service
+        fi
+      done
+EOF
+    fi
+}
+
+function start_service() {
+  host="$1"
+  service="$2"
+
+  if [[ $service == "tserver" ]]; then
+    control_tserver_service "$host" start
+    return
+  fi
+
+  if [[ $host == "localhost" || $host == $(hostname -f) || $host == $(hostname -s) || $host == $(get_ip) ]]; then
+    find /etc/systemd/system/ -type f -name "accumulo_${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl start
+  else
+    $SSH "$host" /bin/bash <<EOF
+    find /etc/systemd/system/ -type f -name "accumulo_${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl start
+EOF
+  fi
+}
+
+function start_tservers() {
+  echo -n "Starting tablet servers ..."
+  count=1
+  for server in $(grep -E -v '(^#|^\s*$)' "${conf}/tservers"); do
+    echo -n "."
+    start_service "$server" tserver &
+    if (( ++count % 72 == 0 )) ;
+    then
+      echo
+      wait
+    fi
+  done
+  echo " done"
+}
+
+function start_all() {
+  unset DISPLAY
+
+  for host in $(grep -E -v '(^#|^\s*$)' "${conf}/monitor"); do
+    start_service "$host" monitor &
+  done
+  wait
+
+  if [[ "$1" != "--no-tservers" ]]; then
+    start_tservers
+  fi
+
+  for host in $(grep -E -v '(^#|^\s*$)' "${conf}/masters"); do
+    start_service "$host" master &
+  done
+  wait
+
+  for host in $(grep -E -v '(^#|^\s*$)' "${conf}/gc"); do
+    start_service "$host" gc &
+  done
+  wait
+
+  for host in $(grep -E -v '(^#|^\s*$)' "${conf}/tracers"); do
+    start_service "$host" tracer &
+  done
+  wait
+}
+
+function start_here() {
+
+  local_hosts="$(hostname -a 2> /dev/null) $(hostname) localhost 127.0.0.1 $(get_ip)"
+  for host in $local_hosts; do
+    if grep -q "^${host}\$" "${conf}/tservers"; then
+      start_service "$host" tserver
+      break
+    fi
+  done
+
+  for host in $local_hosts; do
+    if grep -q "^${host}\$" "${conf}/masters"; then
+      start_service "$host" master
+      break
+    fi
+  done
+
+  for host in $local_hosts; do
+    if grep -q "^${host}\$" "${conf}/gc"; then
+      start_service "$host" gc
+      break
+    fi
+  done
+
+  for host in $local_hosts; do
+    if grep -q "^${host}\$" "${conf}/monitor"; then
+      start_service "$host" monitor
+      break
+    fi
+  done
+
+  for host in $local_hosts; do
+    if grep -q "^${host}\$" "${conf}/tracers"; then
+      start_service "$host" tracer
+      break
+    fi
+  done
+}
+
+function stop_service() {
+  host="$1"
+  service="$2"
+
+  if [[ $service == "tserver" ]]; then
+    control_tserver_service "$host" stop
+    return
+  fi
+
+  if [[ $host == "localhost" || $host == $(hostname -f) || $host == $(hostname -s) || $host == $(get_ip) ]]; then
+    find /etc/systemd/system/ -type f -name "accumulo_${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl stop
+  else
+    $SSH "$host" /bin/bash <<EOF
+    find /etc/systemd/system/ -type f -name "accumulo_${service}*" | cut -d'/' -f5 | xargs -r sudo systemctl stop
+EOF
+  fi
+}
+
+function stop_tservers() {
+  tserver_hosts=$(grep -E -v '(^#|^\s*$)' "${conf}/tservers")
+
+  echo "Stopping unresponsive tablet servers (if any)..."
+  for host in ${tserver_hosts}; do
+    stop_service "$host" tserver &
+  done
+
+  sleep 10
+
+  echo "Cleaning tablet server entries from zookeeper"
+  ${accumulo_cmd} org.apache.accumulo.server.util.ZooZap -tservers
+}
+
+function stop_all() {
+  echo "Stopping Accumulo cluster..."
+  if ! ${accumulo_cmd} admin stopAll
+  then
+    echo "Invalid password or unable to connect to the master"
+    echo "Initiating forced shutdown in 15 seconds (Ctrl-C to abort)"
+    sleep 10
+    echo "Initiating forced shutdown in  5 seconds (Ctrl-C to abort)"
+  else
+    echo "Accumulo shut down cleanly"
+    echo "Utilities and unresponsive servers will shut down in 5 seconds (Ctrl-C to abort)"
+  fi
+
+  sleep 5
+
+  # Look for processes not killed by 'admin stopAll'
+  for master in $(grep -v '^#' "${conf}/masters"); do
+    stop_service "$master" master &
+  done
+  wait
+
+  for gc in $(grep -v '^#' "${conf}/gc"); do
+    stop_service "$gc" gc &
+  done
+  wait
+
+  for monitor in $(grep -v '^#' "${conf}/gc"); do
+    stop_service "$monitor" monitor &
+  done
+  wait
+
+  for tracer in $(grep -E -v '(^#|^\s*$)' "${conf}/tracers"); do
+    stop_service "$tracer" tracer &
+  done
+  wait
+
+  # stop tserver still running
+  stop_tservers
+
+  echo "Cleaning all server entries in ZooKeeper"
+  ${accumulo_cmd} org.apache.accumulo.server.util.ZooZap -master -tservers -tracers
+}
+
+function stop_here() {
+  # Determine hostname without errors to user
+  hosts_to_check=("$(hostname -a 2> /dev/null | head -1)" "$(hostname -f)")
+
+  for host in "${hosts_to_check[@]}"; do
+    for svc in  tserver gc master monitor tracer; do
+      stop_service "$host" "$svc"
+    done
+  done
+}
+
+function main() {
+
+  if [[ -z $1 ]]; then
+    invalid_args "<command> cannot be empty"
+  fi
+
+  # Resolve base directory
+  SOURCE="${BASH_SOURCE[0]}"
+  while [ -h "${SOURCE}" ]; do
+     bin="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
+     SOURCE="$(readlink "${SOURCE}")"
+     [[ "${SOURCE}" != /* ]] && SOURCE="${bin}/${SOURCE}"
+  done
+  bin="$( cd -P "$( dirname "${SOURCE}" )" && pwd )"
+  basedir=$( cd -P "${bin}"/.. && pwd )
+  conf="${ACCUMULO_CONF_DIR:-${basedir}/conf}"
+
+  accumulo_cmd="${bin}/accumulo"
+  SSH='ssh -q -o ConnectTimeout=2'
+
+  case "$1" in
+    create-config)
+      echo "localhost" > "$conf/gc"
+      echo "localhost" > "$conf/masters"
+      echo "localhost" > "$conf/monitor"
+      echo "localhost" > "$conf/tracers"
+      echo "localhost" > "$conf/tservers"
+      ;;
+    restart)
+      verify_config
+      stop_all
+      # Make sure the JVM has a chance to fully exit
+      sleep 1
+      start_all
+      ;;
+    start)
+      verify_config
+      start_all
+      ;;
+    stop)
+      verify_config
+      stop_all
+      ;;
+    start-non-tservers)
+      verify_config
+      start_all --no-tservers
+      ;;
+    start-tservers)
+      verify_config
+      start_tservers
+      ;;
+    start-here)
+      verify_config
+      start_here
+      ;;
+    stop-tservers)
+      verify_config
+      stop_tservers
+      ;;
+    stop-here)
+      verify_config
+      stop_here
+      ;;
+    *)
+      invalid_args "'$1' is an invalid <command>"
+      ;;
+  esac
+}
+
+main "$@"

--- a/ansible/roles/accumulo/tasks/main.yml
+++ b/ansible/roles/accumulo/tasks/main.yml
@@ -61,3 +61,15 @@
     creates: "{{ accumulo_home }}/lib/native/libaccumulo.so"
 - name: "Create accumulo log dir"
   file: path={{ worker_data_dirs[0] }}/logs/accumulo state=directory
+- name: "Copy the modified accumulo-cluster script that supports systemd to bin"
+  copy: src=roles/accumulo/files/accumulo-cluster-systemd dest={{ accumulo_home }}/bin/accumulo-cluster-systemd mode=0755
+  when: use_systemd == True
+- name: "Remove the exisiting accumulo-service and accumulo-cluster scripts"
+  file: path={{ accumulo_home }}/bin/{{ item }} state=absent
+  with_items:
+    - accumulo-service
+    - accumulo-cluster
+  when: use_systemd == True
+- name: "Create a symlink for accumulo-cluster-systemd"
+  file: src={{ accumulo_home }}/bin/accumulo-cluster-systemd dest={{ accumulo_home }}/bin/accumulo-cluster mode=0755 state=link
+  when: use_systemd == True

--- a/ansible/roles/accumulo/tasks/start-gc.yml
+++ b/ansible/roles/accumulo/tasks/start-gc.yml
@@ -18,12 +18,12 @@
 - name: install accumulo gc systemd unit file
   template:
     src: roles/accumulo/templates/gc.j2 
-    dest: "/etc/systemd/system/accumulo_gc.service"
+    dest: "/etc/systemd/system/accumulo-gc.service"
     mode: 0644
 
-- name: start accumulo_gc using systemd
+- name: start accumulo-gc using systemd
   systemd: 
     state: started 
-    name: "accumulo_gc"
+    name: "accumulo-gc"
     daemon_reload: yes
     enabled: yes

--- a/ansible/roles/accumulo/tasks/start-gc.yml
+++ b/ansible/roles/accumulo/tasks/start-gc.yml
@@ -1,0 +1,29 @@
+#
+### Licensed to the Apache Software Foundation (ASF) under one or more
+### contributor license agreements.  See the NOTICE file distributed with
+### this work for additional information regarding copyright ownership.
+### The ASF licenses this file to You under the Apache License, Version 2.0
+### (the "License"); you may not use this file except in compliance with
+### the License.  You may obtain a copy of the License at
+###
+###    http://www.apache.org/licenses/LICENSE-2.0
+###
+### Unless required by applicable law or agreed to in writing, software
+### distributed under the License is distributed on an "AS IS" BASIS,
+### WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+### See the License for the specific language governing permissions and
+### limitations under the License.
+###
+##
+- name: install accumulo gc systemd unit file
+  template:
+    src: roles/accumulo/templates/gc.j2 
+    dest: "/etc/systemd/system/accumulo_gc.service"
+    mode: 0644
+
+- name: start accumulo_gc using systemd
+  systemd: 
+    state: started 
+    name: "accumulo_gc"
+    daemon_reload: yes
+    enabled: yes

--- a/ansible/roles/accumulo/tasks/start-master.yml
+++ b/ansible/roles/accumulo/tasks/start-master.yml
@@ -1,0 +1,29 @@
+#
+### Licensed to the Apache Software Foundation (ASF) under one or more
+### contributor license agreements.  See the NOTICE file distributed with
+### this work for additional information regarding copyright ownership.
+### The ASF licenses this file to You under the Apache License, Version 2.0
+### (the "License"); you may not use this file except in compliance with
+### the License.  You may obtain a copy of the License at
+###
+###    http://www.apache.org/licenses/LICENSE-2.0
+###
+### Unless required by applicable law or agreed to in writing, software
+### distributed under the License is distributed on an "AS IS" BASIS,
+### WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+### See the License for the specific language governing permissions and
+### limitations under the License.
+###
+##
+- name: install accumulo master systemd unit file
+  template:
+    src: roles/accumulo/templates/master.j2 
+    dest: "/etc/systemd/system/accumulo_master.service"
+    mode: 0644
+
+- name: start accumulo_master using systemd
+  systemd: 
+    state: started 
+    name: "accumulo_master"
+    daemon_reload: yes
+    enabled: yes

--- a/ansible/roles/accumulo/tasks/start-master.yml
+++ b/ansible/roles/accumulo/tasks/start-master.yml
@@ -18,12 +18,12 @@
 - name: install accumulo master systemd unit file
   template:
     src: roles/accumulo/templates/master.j2 
-    dest: "/etc/systemd/system/accumulo_master.service"
+    dest: "/etc/systemd/system/accumulo-master.service"
     mode: 0644
 
-- name: start accumulo_master using systemd
+- name: start accumulo-master using systemd
   systemd: 
     state: started 
-    name: "accumulo_master"
+    name: "accumulo-master"
     daemon_reload: yes
     enabled: yes

--- a/ansible/roles/accumulo/tasks/start-monitor.yml
+++ b/ansible/roles/accumulo/tasks/start-monitor.yml
@@ -18,12 +18,12 @@
 - name: install accumulo monitor systemd unit file
   template:
     src: roles/accumulo/templates/monitor.j2 
-    dest: "/etc/systemd/system/accumulo_monitor.service"
+    dest: "/etc/systemd/system/accumulo-monitor.service"
     mode: 0644
 
-- name: start accumulo_monitor using systemd
+- name: start accumulo-monitor using systemd
   systemd: 
     state: started 
-    name: "accumulo_monitor"
+    name: "accumulo-monitor"
     daemon_reload: yes
     enabled: yes

--- a/ansible/roles/accumulo/tasks/start-monitor.yml
+++ b/ansible/roles/accumulo/tasks/start-monitor.yml
@@ -1,0 +1,29 @@
+#
+### Licensed to the Apache Software Foundation (ASF) under one or more
+### contributor license agreements.  See the NOTICE file distributed with
+### this work for additional information regarding copyright ownership.
+### The ASF licenses this file to You under the Apache License, Version 2.0
+### (the "License"); you may not use this file except in compliance with
+### the License.  You may obtain a copy of the License at
+###
+###    http://www.apache.org/licenses/LICENSE-2.0
+###
+### Unless required by applicable law or agreed to in writing, software
+### distributed under the License is distributed on an "AS IS" BASIS,
+### WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+### See the License for the specific language governing permissions and
+### limitations under the License.
+###
+##
+- name: install accumulo monitor systemd unit file
+  template:
+    src: roles/accumulo/templates/monitor.j2 
+    dest: "/etc/systemd/system/accumulo_monitor.service"
+    mode: 0644
+
+- name: start accumulo_monitor using systemd
+  systemd: 
+    state: started 
+    name: "accumulo_monitor"
+    daemon_reload: yes
+    enabled: yes

--- a/ansible/roles/accumulo/tasks/start-tracer.yml
+++ b/ansible/roles/accumulo/tasks/start-tracer.yml
@@ -18,12 +18,12 @@
 - name: install accumulo tracer systemd unit file
   template:
     src: roles/accumulo/templates/tracer.j2 
-    dest: "/etc/systemd/system/accumulo_tracer.service"
+    dest: "/etc/systemd/system/accumulo-tracer.service"
     mode: 0644
 
-- name: start accumulo_tracer using systemd
+- name: start accumulo-tracer using systemd
   systemd: 
     state: started 
-    name: "accumulo_tracer"
+    name: "accumulo-tracer"
     daemon_reload: yes
     enabled: yes

--- a/ansible/roles/accumulo/tasks/start-tracer.yml
+++ b/ansible/roles/accumulo/tasks/start-tracer.yml
@@ -1,0 +1,29 @@
+#
+### Licensed to the Apache Software Foundation (ASF) under one or more
+### contributor license agreements.  See the NOTICE file distributed with
+### this work for additional information regarding copyright ownership.
+### The ASF licenses this file to You under the Apache License, Version 2.0
+### (the "License"); you may not use this file except in compliance with
+### the License.  You may obtain a copy of the License at
+###
+###    http://www.apache.org/licenses/LICENSE-2.0
+###
+### Unless required by applicable law or agreed to in writing, software
+### distributed under the License is distributed on an "AS IS" BASIS,
+### WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+### See the License for the specific language governing permissions and
+### limitations under the License.
+###
+##
+- name: install accumulo tracer systemd unit file
+  template:
+    src: roles/accumulo/templates/tracer.j2 
+    dest: "/etc/systemd/system/accumulo_tracer.service"
+    mode: 0644
+
+- name: start accumulo_tracer using systemd
+  systemd: 
+    state: started 
+    name: "accumulo_tracer"
+    daemon_reload: yes
+    enabled: yes

--- a/ansible/roles/accumulo/tasks/start-tserver.yml
+++ b/ansible/roles/accumulo/tasks/start-tserver.yml
@@ -1,0 +1,30 @@
+#
+### Licensed to the Apache Software Foundation (ASF) under one or more
+### contributor license agreements.  See the NOTICE file distributed with
+### this work for additional information regarding copyright ownership.
+### The ASF licenses this file to You under the Apache License, Version 2.0
+### (the "License"); you may not use this file except in compliance with
+### the License.  You may obtain a copy of the License at
+###
+###    http://www.apache.org/licenses/LICENSE-2.0
+###
+### Unless required by applicable law or agreed to in writing, software
+### distributed under the License is distributed on an "AS IS" BASIS,
+### WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+### See the License for the specific language governing permissions and
+### limitations under the License.
+###
+##
+- name: install accumulo tserver systemd unit file
+  template:
+    src: roles/accumulo/templates/tserver.j2 
+    dest: "/etc/systemd/system/accumulo_tserver@.service"
+    mode: 0644
+
+- name: start accumulo_tserver(s) using systemd
+  systemd: 
+    state: started 
+    name: "accumulo_tserver@{{ item }}.service"
+    daemon_reload: yes
+    enabled: yes
+  with_sequence: "start=1 end={{ num_tservers }}"

--- a/ansible/roles/accumulo/tasks/start-tserver.yml
+++ b/ansible/roles/accumulo/tasks/start-tserver.yml
@@ -18,13 +18,13 @@
 - name: install accumulo tserver systemd unit file
   template:
     src: roles/accumulo/templates/tserver.j2 
-    dest: "/etc/systemd/system/accumulo_tserver@.service"
+    dest: "/etc/systemd/system/accumulo-tserver@.service"
     mode: 0644
 
-- name: start accumulo_tserver(s) using systemd
+- name: start accumulo-tserver(s) using systemd
   systemd: 
     state: started 
-    name: "accumulo_tserver@{{ item }}.service"
+    name: "accumulo-tserver@{{ item }}.service"
     daemon_reload: yes
     enabled: yes
   with_sequence: "start=1 end={{ num_tservers }}"

--- a/ansible/roles/accumulo/templates/accumulo.properties
+++ b/ansible/roles/accumulo/templates/accumulo.properties
@@ -48,3 +48,8 @@ general.volume.chooser=org.apache.accumulo.server.fs.PreferredVolumeChooser
 general.custom.volume.preferred.default={{ instance_volumes_preferred }}
 general.custom.volume.preferred.logger={{ hdfs_root }}/accumulo
 {% endif %}
+
+{% if num_tservers > 1 %}
+tserver.port.search = true
+replication.receipt.service.port = 0
+{% endif %}

--- a/ansible/roles/accumulo/templates/gc.j2
+++ b/ansible/roles/accumulo/templates/gc.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=GC Service for Accumulo
+Requires=network.target 
+After=network.target
+
+[Service]
+User={{ cluster_user }}
+Group={{ cluster_group }}
+Type=simple
+ExecStart={{ accumulo_home }}/bin/accumulo gc
+Environment=ACCUMULO_HOME={{ accumulo_home }}
+Environment=JAVA_HOME={{ java_home }}
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=2min
+Restart=on-failure
+RestartSec=1
+StartLimitInterval=1m
+StartLimitBurst=30
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/accumulo/templates/master.j2
+++ b/ansible/roles/accumulo/templates/master.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Master Service for Accumulo
+Requires=network.target 
+After=network.target
+
+[Service]
+User={{ cluster_user }}
+Group={{ cluster_group }}
+Type=simple
+ExecStartPre={{ accumulo_home }}/bin/accumulo org.apache.accumulo.master.state.SetGoalState NORMAL
+ExecStart={{ accumulo_home }}/bin/accumulo master
+Environment=ACCUMULO_HOME={{ accumulo_home }}
+Environment=JAVA_HOME={{ java_home }}
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=2min
+Restart=on-failure
+RestartSec=1
+StartLimitInterval=1m
+StartLimitBurst=30
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/accumulo/templates/monitor.j2
+++ b/ansible/roles/accumulo/templates/monitor.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=Monitor Service for Accumulo
+Requires=network.target 
+After=network.target
+
+[Service]
+User={{ cluster_user }}
+Group={{ cluster_group }}
+Type=simple
+ExecStart={{ accumulo_home }}/bin/accumulo monitor
+Environment=ACCUMULO_HOME={{ accumulo_home }}
+Environment=JAVA_HOME={{ java_home }}
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=2min
+Restart=on-failure
+RestartSec=1
+StartLimitInterval=1m
+StartLimitBurst=30
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/accumulo/templates/tracer.j2
+++ b/ansible/roles/accumulo/templates/tracer.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=Tracer Service for Accumulo
+Requires=network.target 
+After=network.target
+
+[Service]
+User={{ cluster_user }}
+Group={{ cluster_group }}
+Type=simple
+ExecStart={{ accumulo_home }}/bin/accumulo tracer
+Environment=ACCUMULO_HOME={{ accumulo_home }}
+Environment=JAVA_HOME={{ java_home }}
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=2min
+Restart=on-failure
+RestartSec=1
+StartLimitInterval=1m
+StartLimitBurst=30
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/accumulo/templates/tserver.j2
+++ b/ansible/roles/accumulo/templates/tserver.j2
@@ -7,7 +7,7 @@ After=network.target
 User={{ cluster_user }}
 Group={{ cluster_group }}
 Type=simple
-ExecStart={{ accumulo_home }}/bin/accumulo tserver{{''}}
+ExecStart={{ accumulo_home }}/bin/accumulo tserver
 Environment=ACCUMULO_HOME={{ accumulo_home }}
 Environment=JAVA_HOME={{ java_home }}
 Environment=ACCUMULO_SERVICE_INSTANCE=%I

--- a/ansible/roles/accumulo/templates/tserver.j2
+++ b/ansible/roles/accumulo/templates/tserver.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=TServer Service for Accumulo
+Requires=network.target 
+After=network.target
+
+[Service]
+User={{ cluster_user }}
+Group={{ cluster_group }}
+Type=simple
+ExecStart={{ accumulo_home }}/bin/accumulo tserver{{''}}
+Environment=ACCUMULO_HOME={{ accumulo_home }}
+Environment=JAVA_HOME={{ java_home }}
+Environment=ACCUMULO_SERVICE_INSTANCE=%I
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=2min
+Restart=on-failure
+RestartSec=1
+StartLimitInterval=1m
+StartLimitBurst=30
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/wipe-systemd.yml
+++ b/ansible/wipe-systemd.yml
@@ -24,15 +24,15 @@
       state: stopped
       enabled: no
     with_items:
-      - "accumulo_master.service"
-      - "accumulo_monitor.service"
-      - "accumulo_gc.service"
-      - "accumulo_tracer.service"
+      - "accumulo-master.service"
+      - "accumulo-monitor.service"
+      - "accumulo-gc.service"
+      - "accumulo-tracer.service"
     register: stop_disable_service
     failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
 
   - name: "remove accumulo systemd units"
-    file: path="/etc/systemd/system/accumulo_*" state=absent
+    file: path="/etc/systemd/system/-*" state=absent
     register: delete_task
     retries: 10
     delay: 3
@@ -44,7 +44,7 @@
   tasks:
   - name: "disable accumulo tserver systemd services"
     systemd:
-      name: "accumulo_tserver@{{ item }}.service"
+      name: "accumulo-tserver@{{ item }}.service"
       state: stopped
       enabled: no
     with_sequence: "start=1 end={{ num_tservers }}"
@@ -52,7 +52,7 @@
     failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
 
   - name: "remove accumulo tserver systemd units"
-    file: path="/etc/systemd/system/accumulo_tserver*" state=absent
+    file: path="/etc/systemd/system/accumulo-tserver*" state=absent
     register: delete_task
     retries: 10
     delay: 3

--- a/ansible/wipe-systemd.yml
+++ b/ansible/wipe-systemd.yml
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+- hosts: accumulomaster
+  gather_facts: false
+  become: yes
+  tasks:
+  - name: "disable all accumulo systemd services on master"
+    systemd:
+      name: "{{ item }}"
+      state: stopped
+      enabled: no
+    with_items:
+      - "accumulo_master.service"
+      - "accumulo_monitor.service"
+      - "accumulo_gc.service"
+      - "accumulo_tracer.service"
+    register: stop_disable_service
+    failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
+
+  - name: "remove accumulo systemd units"
+    file: path="/etc/systemd/system/accumulo_*" state=absent
+    register: delete_task
+    retries: 10
+    delay: 3
+    until: delete_task is success
+
+- hosts: workers
+  gather_facts: false
+  become: yes
+  tasks:
+  - name: "disable accumulo tserver systemd services"
+    systemd:
+      name: "accumulo_tserver@{{ item }}.service"
+      state: stopped
+      enabled: no
+    with_sequence: "start=1 end={{ num_tservers }}"
+    register: stop_disable_service
+    failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
+
+  - name: "remove accumulo tserver systemd units"
+    file: path="/etc/systemd/system/accumulo_tserver*" state=absent
+    register: delete_task
+    retries: 10
+    delay: 3
+    until: delete_task is success
+
+  - name: "reload config changes"
+    systemd: daemon_reload=yes
+
+  - name: "reset failed on every node"
+    shell: systemctl reset-failed

--- a/ansible/wipe-systemd.yml
+++ b/ansible/wipe-systemd.yml
@@ -32,7 +32,7 @@
     failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
 
   - name: "remove accumulo systemd units"
-    file: path="/etc/systemd/system/-*" state=absent
+    file: path="/etc/systemd/system/accumulo-*" state=absent
     register: delete_task
     retries: 10
     delay: 3

--- a/ansible/wipe.yml
+++ b/ansible/wipe.yml
@@ -28,6 +28,9 @@
   - name: "wipe grafana db"
     file: path=/var/lib/grafana/grafana.db state=absent
 
+- import_playbook: wipe-systemd.yml
+  when: use_systemd == True
+
 - import_playbook: kill.yml
 
 - hosts: all

--- a/conf/muchos.props.example
+++ b/conf/muchos.props.example
@@ -54,6 +54,11 @@ java_package=java-1.8.0-openjdk-devel
 hdfs_ha = False
 # Give a logical name for the cluster, all one word no special characters. Required to support HDFS HA.
 nameservice_id = muchoshacluster
+# number of accumulo tablet servers to run per host. This is only effective when systemd is set to 'True'. Needs changes in
+# accumulo-service script inorder to support non-systemd cases. 
+num_tservers = 1
+# If accumulo services are to be run under systemd, set this to 'True'
+use_systemd = False
 
 [ec2]
 # AWS machine image to use. The default below is for a CentOS 7 image (in us-east-1).

--- a/lib/muchos/config/base.py
+++ b/lib/muchos/config/base.py
@@ -57,6 +57,7 @@ _HOST_VAR_DEFAULTS = {
   'hdfs_root': "{% if hdfs_ha %}hdfs://{{ nameservice_id }}{% else %}hdfs://{{ groups[\'namenode\'][0] }}:8020{% endif %}",
   'hdfs_ha': None,
   'nameservice_id': None,
+  'num_tservers': 1,
   'install_dir': None,
   'install_hub': None,
   'java_home': '"/usr/lib/jvm/java"',
@@ -103,7 +104,8 @@ _PLAY_VAR_DEFAULTS = {
   'shutdown_delay_minutes': None,
   'twill_reserve_mem_mb': None,
   'yarn_nm_mem_mb': None,
-  'zookeeper_checksum': None
+  'zookeeper_checksum': None,
+  'use_systemd': False
 }
 
 _EXTRA_VAR_DEFAULTS = {}


### PR DESCRIPTION
Adds systemd support for accumulo(2.x) services

- This change adds systemd unit files for all accumulo 2.x services and
ansible scripts to start/stop these services using systemd.
- Adds accumulo-cluster-systemd script (modified version of
accumulo-culster script) to use systemd to start/stop
the cluster when systemd is enabled via muchos.props file.
- Copies the modified file to bin and soft links it to
bin/accumulo-cluster
- Removes accumulo-service script as it becomes irrelevant as services
could now be started/stopped via systemctl commands directly.
- Adds support to have multiple tservers per host when systemd is enabled
and the number of tservers can be configured via muchos.props file.
- Adds support to wipe services started via systemd.
- Updates the muchos.props.example file to show usage.

Will submit a follow up PR to have systemd support for hadoop(3.x) and
zookeeper services.
