### PR TITLE
Tweak collectd / statsd perf data collection

### DIFF
--- a/ansible/roles/common/templates/etc/collectd.conf.j2
+++ b/ansible/roles/common/templates/etc/collectd.conf.j2
@@ -5,7 +5,7 @@
 #PluginDir   "/usr/lib64/collectd"
 #TypesDB     "/usr/share/collectd/types.db"
 
-Interval     10
+Interval     60
 
 #Timeout      2
 #ReadThreads  5

--- a/ansible/roles/common/templates/etc/collectd.d/azure.conf.j2
+++ b/ansible/roles/common/templates/etc/collectd.d/azure.conf.j2
@@ -11,5 +11,8 @@ LoadPlugin statsd
   Host "::"
   Port "8125"
   DeleteSets     true
+  DeleteCounters true
+  DeleteTimers   true
+  DeleteGauges   true
   TimerPercentile 90.0
 </Plugin>


### PR DESCRIPTION
* Adjusts the collectd poll interval to conservative 60 seconds to reduce the amount of perf data egressed to metrics sink - either Influx or Azure Log Analytics.

* Ensures that stale counters are removed by the statsd plugin - this can happen for example if a tserver terminates on a node, the last known values for its metrics are otherwise cached by the statsd plugin.