### PR TITLE
Correctly check for Docker swarm status

### DIFF
--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -45,7 +45,7 @@
   tasks:
     - name: get swarm status
       shell: >
-        set -o pipefail && docker info | grep 'Swarm' | sed 's/\s*Swarm\:\s//'
+        set -o pipefail && docker info | grep 'Swarm:' | sed 's/\s*Swarm\:\s*//'
       args:
         executable: bash
       register: swarm_status

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -24,7 +24,7 @@
   tasks:
     - name: get swarm status
       shell: >
-        set -o pipefail && docker info | grep 'Swarm' | sed 's/\s*Swarm\:\s//'
+        set -o pipefail && docker info | grep 'Swarm:' | sed 's/\s*Swarm\:\s*//'
       args:
         executable: bash
       register: swarm_status

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -24,7 +24,7 @@
   tasks:
     - name: get swarm status
       shell: >
-        set -o pipefail && docker info | egrep '^Swarm: ' | cut -d ' ' -f 2
+        set -o pipefail && docker info | grep 'Swarm' | sed 's/\s*Swarm\:\s//'
       args:
         executable: bash
       register: swarm_status
@@ -45,7 +45,7 @@
   tasks:
     - name: get swarm status
       shell: >
-        set -o pipefail && docker info | egrep '^Swarm: ' | cut -d ' ' -f 2
+        set -o pipefail && docker info | grep 'Swarm' | sed 's/\s*Swarm\:\s//'
       args:
         executable: bash
       register: swarm_status

--- a/ansible/kill.yml
+++ b/ansible/kill.yml
@@ -30,7 +30,7 @@
     - name: "stop mesos slaves"
       service: name=mesos-slave state=stopped
       when: "'mesosmaster' in groups"
-- hosts: all
+- hosts: all:!{{ azure_proxy_host }}
   become: yes
   tasks:
   - name: "stop docker"


### PR DESCRIPTION
Fixes #345 - which in turn was caused by extra whitespace now being
printed at the start of the line by `docker info`