### PR TITLE
Support log4j2 w/ Accumulo 2.1.0

### DIFF
--- a/ansible/roles/accumulo/tasks/main.yml
+++ b/ansible/roles/accumulo/tasks/main.yml
@@ -25,18 +25,6 @@
     - monitor_logger.xml
     - log4j.properties
   when: accumulo_major_version == '1'
-- name: "configure accumulo 2.0 configuration"
-  template: src={{ item }} dest={{ accumulo_home }}/conf/{{ item }}
-  with_items:
-    - accumulo-env.sh
-    - accumulo.properties
-    - accumulo-client.properties
-    - gc
-    - tracers
-    - masters
-    - monitor
-    - log4j-service.properties
-  when: accumulo_major_version == '2'
 - name: "configure accumulo 1.0 configuration"
   template: src={{ item }} dest={{ accumulo_home }}/conf/{{ item }}
   with_items:
@@ -48,6 +36,28 @@
     - masters
     - monitor
   when: accumulo_major_version == '1'
+- name: "configure accumulo 2.X configuration"
+  template: src={{ item }} dest={{ accumulo_home }}/conf/{{ item }}
+  with_items:
+    - accumulo-env.sh
+    - accumulo.properties
+    - accumulo-client.properties
+    - gc
+    - tracers
+    - masters
+    - monitor
+  when: accumulo_major_version == '2'
+- name: "configure accumulo 2.0.0 logging"
+  command: cp {{ accumulo_home }}/conf/templates/{{ item }} {{ accumulo_home }}/conf/ creates={{ accumulo_home }}/conf/{{ item }}
+  with_items:
+    - log4j-service.properties
+  when: accumulo_version is version('2.0.0','>=') and accumulo_version is version('2.1.0','<')
+- name: "configure accumulo >= 2.1.0 logging"
+  command: cp {{ accumulo_home }}/conf/templates/{{ item }} {{ accumulo_home }}/conf/ creates={{ accumulo_home }}/conf/{{ item }}
+  with_items:
+    - log4j2.properties
+    - log4j2-service.properties
+  when: accumulo_version is version('2.1.0','>=')
 - name: "configure accumulo to send metrics (if metrics server exists)"
   template: src={{ item }} dest={{ accumulo_home }}/conf/{{ item }}
   with_items:

--- a/ansible/roles/accumulo/templates/log4j2-service.properties
+++ b/ansible/roles/accumulo/templates/log4j2-service.properties
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+## Log4j2 file that configures logging for all Accumulo services
+## The system properties referenced below are configured by accumulo-env.sh
+
+status = info
+dest = err
+name = AccumuloServiceLoggingProperties
+monitorInterval = 30
+
+packages = org.apache.accumulo.monitor.util.logging
+
+property.filename = ${sys:accumulo.log.dir}/${sys:accumulo.application}
+
+appender.console.type = Console
+appender.console.name = STDERR
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = info
+
+appender.rolling.type = RollingFile
+appender.rolling.name = LogFiles
+appender.rolling.fileName = ${filename}.log
+appender.rolling.filePattern = ${filename}-%d{MM-dd-yy-HH}-%i.log.gz
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = true
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size=100MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 10
+
+appender.audit.type = RollingFile
+appender.audit.name = AuditLogFiles
+appender.audit.fileName = ${filename}.audit
+appender.audit.filePattern = ${filename}-%d{MM-dd-yy-HH}-%i.audit.gz
+appender.audit.layout.type = PatternLayout
+appender.audit.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+appender.audit.policies.type = Policies
+appender.audit.policies.time.type = TimeBasedTriggeringPolicy
+appender.audit.policies.time.interval = 1
+appender.audit.policies.time.modulate = true
+appender.audit.policies.size.type = SizeBasedTriggeringPolicy
+appender.audit.policies.size.size=100MB
+appender.audit.strategy.type = DefaultRolloverStrategy
+appender.audit.strategy.max = 10
+
+appender.monitor.type = AccumuloMonitor
+appender.monitor.name = MonitorLog
+appender.monitor.filter.threshold.type = ThresholdFilter
+appender.monitor.filter.threshold.level = warn
+
+logger.zookeeper.name = org.apache.zookeeper
+logger.zookeeper.level = error
+
+logger.accumulo.name = org.apache.accumulo
+logger.accumulo.level = debug
+
+# uncomment for separate audit logs
+#logger.audit.name = org.apache.accumulo.audit
+#logger.audit.level = info
+#logger.audit.additivity = false
+#logger.audit.appenderRef.audit.ref = AuditLogFiles
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = STDERR
+rootLogger.appenderRef.rolling.ref = LogFiles
+rootLogger.appenderRef.monitor.ref = MonitorLog
+

--- a/ansible/roles/accumulo/templates/log4j2.properties
+++ b/ansible/roles/accumulo/templates/log4j2.properties
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+## Log4j2 file that configures logging for processes other than Accumulo services
+
+status = info
+dest = err
+name = AccumuloDefaultLoggingProperties
+monitorInterval = 30
+
+appender.console.type = Console
+appender.console.name = STDERR
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %style{%d{ISO8601}}{dim,cyan} %style{[}{red}%style{%-8c{2}}{dim,blue}%style{]}{red} %highlight{%-5p}%style{:}{red} %m%n
+
+logger.shellaudit.name = org.apache.accumulo.shell.Shell.audit
+logger.shellaudit.level = warn
+
+logger.zookeeper.name = org.apache.zookeeper
+logger.zookeeper.level = error
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = STDERR
+


### PR DESCRIPTION
I tested this change with Accumulo 2.0.0 and 2.1.0-SNAPSHOT.  In both cases logging worked and the files in accumulo/conf looked correct.