### PR TITLE
Update init scope when using multiple volumes in Accumulo 2.1

### DIFF
--- a/ansible/accumulo.yml
+++ b/ansible/accumulo.yml
@@ -30,11 +30,11 @@
 - hosts: all:!{{ azure_proxy_host }}
   tasks:
     - import_tasks: roles/accumulo/tasks/add-adlsgen2.yml
-      when: cluster_type == 'azure' and accumulo_major_version == '2' and use_adlsg2
+      when: cluster_type == 'azure' and accumulo_version is version('2.0.0','>=') and accumulo_version is version('2.1.0','<') and use_adlsg2
 - hosts: accumulomaster[0]
   tasks:
     - import_tasks: roles/accumulo/tasks/init-adlsgen2.yml
-      when: cluster_type == 'azure' and accumulo_major_version == '2' and use_adlsg2
+      when: cluster_type == 'azure' and accumulo_version is version('2.0.0','>=') and accumulo_version is version('2.1.0','<') and use_adlsg2
   handlers:
     - import_tasks: roles/accumulo/handlers/init-adlsgen2.yml
 - hosts: accumulo

--- a/ansible/roles/accumulo/templates/accumulo.properties
+++ b/ansible/roles/accumulo/templates/accumulo.properties
@@ -26,7 +26,11 @@ general.rpc.timeout=240s
 instance.secret=muchos
 
 ## Sets location in HDFS where Accumulo will store data
+{% if cluster_type == 'azure' and use_adlsg2 and accumulo_version is version('2.1.0','>=') %}
+instance.volumes={{ hdfs_root }}/accumulo,{{ instance_volumes_preferred }}
+{% else %}
 instance.volumes={{ hdfs_root }}/accumulo
+{% endif %}
 
 ## Sets location of Zookeepers
 instance.zookeeper.host={{ zookeeper_connect }}
@@ -47,6 +51,10 @@ tserver.walog.max.size=512M
 general.volume.chooser=org.apache.accumulo.server.fs.PreferredVolumeChooser
 general.custom.volume.preferred.default={{ instance_volumes_preferred }}
 general.custom.volume.preferred.logger={{ hdfs_root }}/accumulo
+{% endif %}
+
+{% if cluster_type == 'azure' and use_adlsg2 and accumulo_version is version('2.1.0','>=') %}
+general.custom.volume.preferred.init={{ instance_volumes_preferred }}
 {% endif %}
 
 {% if num_tservers > 1 %}


### PR DESCRIPTION
When multiple volumes are used, Accumulo can randomly place metadata tables and WALs on any of the volumes during the init step. When using Muchos with Accumulo 2.0, we have overcome this by running the init first with `HDFS` as `instance.volumes` and after that add the other volumes like ABFS,S3, etc.. This 2 step approach is no longer needed in Accumulo 2.1, this PR adds the new property `general.custom.volume.preferred.init` to Muchos which will direct 
all the metadata tables and WALs to the volume specified in this property. I have tested this change with 2.1.0-SNAPSHOT & also ensured the existing code still works with 2.0.
