### PR TITLE
Rename instance_volumes_<preferred> to adls

### DIFF
--- a/ansible/azure_terminate.yml
+++ b/ansible/azure_terminate.yml
@@ -67,7 +67,7 @@
          force_delete_nonempty: yes
          state: absent
       loop:
-         "{{ instance_volumes_preferred.split(',') }}"
+         "{{ instance_volumes_adls.split(',') }}"
       when: use_adlsg2
 
     - name: Delete VM Scale Set

--- a/ansible/azure_wipe.yml
+++ b/ansible/azure_wipe.yml
@@ -25,7 +25,7 @@
       state: absent
       force: yes
     loop:
-        "{{ instance_volumes_preferred.split(',') }}"
+        "{{ instance_volumes_adls.split(',') }}"
     when: cluster_type == 'azure' and use_adlsg2
 
   - name: Create container/Filesystem on ADLS Gen2
@@ -38,5 +38,5 @@
     register: result
     until: result is succeeded and (not result.changed or (result.changed and result.container|length > 0))
     loop:
-      "{{ instance_volumes_preferred.split(',')  }}"
+      "{{ instance_volumes_adls.split(',')  }}"
     when: cluster_type == 'azure' and use_adlsg2

--- a/ansible/roles/accumulo/tasks/add-adlsgen2.yml
+++ b/ansible/roles/accumulo/tasks/add-adlsgen2.yml
@@ -18,4 +18,4 @@
   lineinfile:
     path: "{{ accumulo_home }}/conf/accumulo.properties"
     regexp: '^instance.volumes='
-    line: "instance.volumes={{ hdfs_root }}/accumulo,{{ instance_volumes_preferred }}"
+    line: "instance.volumes={{ hdfs_root }}/accumulo,{{ instance_volumes_adls }}"

--- a/ansible/roles/accumulo/tasks/init-adlsgen2.yml
+++ b/ansible/roles/accumulo/tasks/init-adlsgen2.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 - name: "determine if accumulo needs to be initialized on adlsgen2"
-  command: "{{ hadoop_home }}/bin/hdfs dfs -stat {{ instance_volumes_preferred[0] }}"
+  command: "{{ hadoop_home }}/bin/hdfs dfs -stat {{ instance_volumes_adls[0] }}"
   register: adlsgen2_stat
   changed_when: adlsgen2_stat.rc != 0
   failed_when: adlsgen2_stat.rc != 0 and 'No such file or directory' not in adlsgen2_stat.stderr

--- a/ansible/roles/accumulo/templates/accumulo.properties
+++ b/ansible/roles/accumulo/templates/accumulo.properties
@@ -27,7 +27,7 @@ instance.secret=muchos
 
 ## Sets location in HDFS where Accumulo will store data
 {% if cluster_type == 'azure' and use_adlsg2 and accumulo_version is version('2.1.0','>=') %}
-instance.volumes={{ hdfs_root }}/accumulo,{{ instance_volumes_preferred }}
+instance.volumes={{ hdfs_root }}/accumulo,{{ instance_volumes_adls }}
 {% else %}
 instance.volumes={{ hdfs_root }}/accumulo
 {% endif %}
@@ -49,12 +49,12 @@ tserver.walog.max.size=512M
 
 {% if cluster_type == 'azure' and use_adlsg2 %}
 general.volume.chooser=org.apache.accumulo.server.fs.PreferredVolumeChooser
-general.custom.volume.preferred.default={{ instance_volumes_preferred }}
+general.custom.volume.preferred.default={{ instance_volumes_adls }}
 general.custom.volume.preferred.logger={{ hdfs_root }}/accumulo
 {% endif %}
 
 {% if cluster_type == 'azure' and use_adlsg2 and accumulo_version is version('2.1.0','>=') %}
-general.custom.volume.preferred.init={{ instance_volumes_preferred }}
+general.custom.volume.preferred.init={{ instance_volumes_adls }}
 {% endif %}
 
 {% if num_tservers > 1 %}

--- a/ansible/roles/azure/tasks/create_adlsgen2.yml
+++ b/ansible/roles/azure/tasks/create_adlsgen2.yml
@@ -22,7 +22,7 @@
 # 2. Create User Assigned Identity.
 # 3. Assign roles to storage accounts.
 # 4. Create filesystem / container in storage accounts.
-# 5. Update tenant_id, client_id and instance_volumes_preferred in muchos.props.
+# 5. Update tenant_id, client_id and instance_volumes_adls in muchos.props.
 # 6. Assign User Assigned Identity to VMSS.
 
 - name: Generate MD5 checksum based on resource_group name, vmss_name and cluster name
@@ -70,11 +70,11 @@
   set_fact:
      InstanceVolumes: "{{ InstanceVolumesManual if  instance_volumes_input.split('|')[0].split(',') ==  [''] else InstanceVolumesAuto }}"
 
-- name: Update instance_volumes_preferred  in muchos.props
+- name: Update instance_volumes_adls  in muchos.props
   lineinfile:
     path: "{{ deploy_path }}/conf/muchos.props"
-    regexp: '^instance_volumes_preferred\s*=\s*|^[#]instance_volumes_preferred\s*=\s*'
-    line: "instance_volumes_preferred = {{ InstanceVolumes|join(',') }}"
+    regexp: '^instance_volumes_adls\s*=\s*|^[#]instance_volumes_adls\s*=\s*'
+    line: "instance_volumes_adls = {{ InstanceVolumes|join(',') }}"
 
 # Not registering variable because storage values are not visible immediately
 - name: Create ADLS Gen2 storage account using REST API

--- a/conf/muchos.props.example
+++ b/conf/muchos.props.example
@@ -142,7 +142,7 @@ metrics_drive_root = var-data
 # Optional proxy VM. If not set, the first node of the cluster will be selected as the proxy.
 azure_proxy_host =
 location = westus2
-# Enable ADLS Gen2 storage configuration. Muchos parameters instance_volumes_input, instance_volumes_preferred & adls_storage_type is not required if use_adlsg2 is false.
+# Enable ADLS Gen2 storage configuration. Muchos parameters instance_volumes_input, instance_volumes_adls & adls_storage_type is not required if use_adlsg2 is false.
 use_adlsg2 = False
 # Storage accounts can be auto generated or manually specified. "|" is used as separator between manual and auto generated storage account names and must be specified
 # Manual and Auto generated names are mutually exclusive
@@ -155,8 +155,8 @@ use_adlsg2 = False
 #   <Number-of-Storage-Accounts>,<domain-name>|
 #   Example: 3,dfs.core.windows.net|
 instance_volumes_input = 1,dfs.core.windows.net|
-# Do not update "instance_volumes_preferred", it will be populated dynamically during launch phase of muchos
-instance_volumes_preferred =
+# Do not update "instance_volumes_adls", it will be populated dynamically during launch phase of muchos
+instance_volumes_adls =
 # Type of storage for ADLS Gen2 storage accounts
 adls_storage_type = Standard_LRS
 # Specify user assigned identity name. "{{ vmss_name }}-ua-msi"  will be created if value is not provided

--- a/lib/muchos/config/azure.py
+++ b/lib/muchos/config/azure.py
@@ -180,7 +180,7 @@ class AzureDeployConfig(BaseConfig):
     def principal_id(self):
         return self.get("azure", "principal_id")
 
-    @ansible_host_var(name="instance_volumes_preferred")
+    @ansible_host_var(name="instance_volumes_adls")
     @default(None)
-    def instance_volumes_preferred(self):
-        return self.get("azure", "instance_volumes_preferred")
+    def instance_volumes_adls(self):
+        return self.get("azure", "instance_volumes_adls")


### PR DESCRIPTION
The value of the key is always going to be an ADLS URI. Hence renaming the key to `instance_volumes_adls` to make it more apt and clearer for someone walking through the code.