### PR TITLE
Default to using HDFS nameservice_id for hdfs_root

### DIFF
--- a/lib/muchos/config/base.py
+++ b/lib/muchos/config/base.py
@@ -80,10 +80,7 @@ _HOST_VAR_DEFAULTS = {
     "hadoop_tarball": "hadoop-{{ hadoop_version }}.tar.gz",
     "hadoop_version": None,
     "hadoop_major_version": "{{ hadoop_version.split('.')[0] }}",
-    "hdfs_root": (
-        "{% if hdfs_ha %}hdfs://{{ nameservice_id }}{% else %}"
-        "hdfs://{{ groups['namenode'][0] }}:8020{% endif %}"
-    ),
+    "hdfs_root": "hdfs://{{ nameservice_id }}",
     "hdfs_ha": None,
     "nameservice_id": None,
     "num_tservers": 1,


### PR DESCRIPTION
Simplifies hdfs_root to point to the nameservice_id URL. This was
enabled by underlying changes in #356. Further, the Fluo role was also
fixed to work correctly with HDFS nameservice URLs in #357.