### PR TITLE
Update Influxdb checksum

### DIFF
--- a/ansible/roles/influxdb/defaults/main.yml
+++ b/ansible/roles/influxdb/defaults/main.yml
@@ -16,4 +16,4 @@
 #
 
 influxdb_rpm: influxdb-1.8.3.x86_64.rpm
-influxdb_checksum: "sha512:63b09f640e88e2b3dfa4917f7feeef5d0daf29a7ae9e3cc158ab3ff2aecf6f5a73671eb1a95cc77befaff6358e70329e58194f3c01acf805d1ae73efce165dd8"
+influxdb_checksum: "sha512:4c0557c24e5083e9d94d49cfad496f45421bb50aacf75737ca6bff36c8ef276af884c5419b5cc74e4fa1e8062e6bee18af53e3650eaa8a6ecd656346151ea87c"


### PR DESCRIPTION
Whilst setting up the cluster for testing Accumulo 1.10.1-rc1, noticed Inflxudb 1.8.3 checksum had changed in the [source](https://repos.influxdata.com/centos/7/x86_64/stable/) end on 12 Nov 2020. This was after #379. 