### PR TITLE
Muchos to support rename from master to manager in Accumulo 2.1

### DIFF
--- a/ansible/roles/accumulo/tasks/main.yml
+++ b/ansible/roles/accumulo/tasks/main.yml
@@ -47,6 +47,10 @@
     - masters
     - monitor
   when: accumulo_major_version == '2'
+- name: "Rename 'masters' file to 'managers' when using Accumulo 2.1 or above"
+  shell: |
+    [[ -e {{ accumulo_home }}/conf/masters ]] && mv {{ accumulo_home }}/conf/masters {{ accumulo_home }}/conf/managers || echo "Nothing to do"
+  when: accumulo_version is version('2.1.0','>=')
 - name: "configure accumulo 2.0.0 logging"
   command: cp {{ accumulo_home }}/conf/templates/{{ item }} {{ accumulo_home }}/conf/ creates={{ accumulo_home }}/conf/{{ item }}
   with_items:

--- a/ansible/roles/accumulo/templates/accumulo-env.sh
+++ b/ansible/roles/accumulo/templates/accumulo-env.sh
@@ -79,7 +79,7 @@ JAVA_OPTS=("${ACCUMULO_JAVA_OPTS[@]}"
   "-Daccumulo.native.lib.path=${lib}/native")
 
 case "$cmd" in
-  master)  JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx512m' '-Xms512m') ;;
+  {{ master_manager }})  JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx512m' '-Xms512m') ;;
   monitor) JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx256m' '-Xms256m') ;;
   gc)      JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx256m' '-Xms256m') ;;
   tserver) JAVA_OPTS=("${JAVA_OPTS[@]}" '-Xmx{{ accumulo_tserv_mem }}' '-Xms{{ accumulo_tserv_mem }}') ;;
@@ -99,7 +99,7 @@ JAVA_OPTS=("${JAVA_OPTS[@]}"
 
 case "$cmd" in
 {% if accumulo_version is version('2.1.0','>=') %}
-  monitor|gc|master|tserver|tracer)
+  monitor|gc|manager|tserver|tracer)
     JAVA_OPTS=("${JAVA_OPTS[@]}" "-Dlog4j.configurationFile=log4j2-service.properties")
     ;;
 {% else %}

--- a/conf/muchos.props.example
+++ b/conf/muchos.props.example
@@ -37,11 +37,11 @@ accumulo_instance = muchos
 accumulo_password = secret
 # Software versions (make sure you have a corresponding entry for the checksum in conf/checksums)
 hadoop_version = 3.2.1
-zookeeper_version = 3.5.8
+zookeeper_version = 3.6.2
 spark_version = 2.4.5
 fluo_version = 1.2.0
 fluo_yarn_version = 1.0.0
-accumulo_version = 2.0.0
+accumulo_version = 2.0.1
 # Specifies if software should be downloaded. If 'False', tarballs of the software above should be in conf/upload/
 download_software = True
 # Install Hub (for GitHub)

--- a/lib/muchos/config/base.py
+++ b/lib/muchos/config/base.py
@@ -635,3 +635,8 @@ class BaseConfig(ConfigParser, metaclass=ABCMeta):
         except ValueError:
             return default
         return val
+
+    @ansible_host_var
+    def master_manager(self):
+        accumulo_version = self.get("general", "accumulo_version")
+        return "manager" if accumulo_version >= '2.1.0' else "master"

--- a/lib/tests/azure/test_config.py
+++ b/lib/tests/azure/test_config.py
@@ -38,8 +38,9 @@ def test_azure_cluster():
         "f68a6145029a9ea843b0305c90a7f5f0334d8a8ceeea94734267ec36421fe7fe"
     )
     assert c.checksum("accumulo") == (
-        "sha256:"
-        "df172111698c7a73aa031de09bd5589263a6b824482fbb9b4f0440a16602ed47"
+        "sha512:"
+        "b443839443a9f5098b55bc5c54be10c11fedbaea554ee6cd42eaa9311068c70b"
+        "d611d7fc67698c91ec73da0e85b9907aa72b98d5eb4d49ea3a5d51b0c6c5785f"
     )
     assert c.get("azure", "vm_sku") == "Standard_D8s_v3"
     assert c.get("azure", "managed_disk_type") == "Standard_LRS"

--- a/lib/tests/ec2/test_config.py
+++ b/lib/tests/ec2/test_config.py
@@ -32,8 +32,9 @@ def test_ec2_cluster():
         "f68a6145029a9ea843b0305c90a7f5f0334d8a8ceeea94734267ec36421fe7fe"
     )
     assert c.checksum("accumulo") == (
-        "sha256:"
-        "df172111698c7a73aa031de09bd5589263a6b824482fbb9b4f0440a16602ed47"
+        "sha512:"
+        "b443839443a9f5098b55bc5c54be10c11fedbaea554ee6cd42eaa9311068c70b"
+        "d611d7fc67698c91ec73da0e85b9907aa72b98d5eb4d49ea3a5d51b0c6c5785f"
     )
     assert c.get("ec2", "default_instance_type") == "m5d.large"
     assert c.get("ec2", "worker_instance_type") == "m5d.large"


### PR DESCRIPTION
Additionally, 
	- Updated Accumulo & ZK versions to `2.0.1` & `3.6.2`. As existing versions no longer available in the Apache mirror
	- Updated `test_config.py` to include Accumulo 2.0.1 checksum. Found this when running nosetests
	
For the record, these changes were tested against Accumulo 2.0.1 & Accumulo 2.1.0-SNAPSHOT