### PR TITLE
Fix wipe-systemd to clear Accumulo systemd units

### DIFF
--- a/ansible/wipe-systemd.yml
+++ b/ansible/wipe-systemd.yml
@@ -31,8 +31,16 @@
     register: stop_disable_service
     failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
 
-  - name: "remove accumulo systemd units"
-    file: path="/etc/systemd/system/accumulo-*" state=absent
+  - name: "find accumulo systemd units to remove in masters"
+    find:
+      paths: /etc/systemd/system
+      patterns: 'accumulo-*.service'
+    register: find_accumulo_services
+
+  - name: "remove accumulo systemd units in masters"
+    file: path="{{ item.path }}" state=absent
+    with_items:
+      - "{{ find_accumulo_services.files }}"
     register: delete_task
     retries: 10
     delay: 3
@@ -51,8 +59,16 @@
     register: stop_disable_service
     failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
 
-  - name: "remove accumulo tserver systemd units"
-    file: path="/etc/systemd/system/accumulo-tserver*" state=absent
+  - name: "find accumulo tserver systemd units to remove in workers"
+    find:
+      paths: /etc/systemd/system
+      patterns: 'accumulo-*.service'
+    register: find_accumulo_tserver
+
+  - name: "remove accumulo tserver systemd units in workers"
+    file: path="{{ item.path }}" state=absent
+    with_items:
+      - "{{ find_accumulo_tserver.files }}"
     register: delete_task
     retries: 10
     delay: 3


### PR DESCRIPTION
The existing code wasn't removing the systemd units when running wipe command