### PR TITLE
Add conf/keys to Azure proxy ssh authorized_keys.

### DIFF
--- a/ansible/roles/proxy/tasks/main.yml
+++ b/ansible/roles/proxy/tasks/main.yml
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+- name: "add conf/keys to ~/.ssh/authorized_keys"
+  authorized_key: user={{ cluster_user }} key="{{ lookup('file', 'conf/keys') }}"
+  tags: configure_os
 - name: "ensure cluster user exists and generate ssh key"
   user: name={{ cluster_user }} generate_ssh_key=yes ssh_key_bits=4096 state=present
   become: yes


### PR DESCRIPTION
If SSH public keys exist in the file conf/keys, then they are addded to
the cluster user's .ssh/authorized_keys file on the created cluster, but
not on the Azure proxy node, if used. This change adds the keys to the
proxy node as well.