### PR TITLE
Respect existing CLASSPATH in accumulo-env.sh

### DIFF
--- a/ansible/roles/accumulo/templates/accumulo-env.sh
+++ b/ansible/roles/accumulo/templates/accumulo-env.sh
@@ -45,7 +45,13 @@ add_jar_prefix_to_classpath() {
     CLASSPATH="${CLASSPATH}:${JAR}"
   done
 }
-CLASSPATH="${conf}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*"
+## Build using existing CLASSPATH, conf/ directory, dependencies in lib/, and external Hadoop & Zookeeper dependencies
+if [[ -n "$CLASSPATH" ]]; then
+  CLASSPATH="${CLASSPATH}:${conf}"
+else
+  CLASSPATH="${conf}"
+fi
+CLASSPATH="${CLASSPATH}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*"
 add_jar_prefix_to_classpath "${ZOOKEEPER_HOME}/lib/zookeeper-"
 CLASSPATH="${CLASSPATH}:${HADOOP_HOME}/share/hadoop/client/*"
 {% if cluster_type == 'azure' and use_adlsg2 %}


### PR DESCRIPTION
With Accumulo 2.0, the accumulo-env.sh file attempts to respect the
existing CLASSPATH supplied to it. Update the muchos version to do the
same.