### PR TITLE
Use cloud-init for Azure deployments

### DIFF
--- a/ansible/roles/azure/files/cloud-init.yml
+++ b/ansible/roles/azure/files/cloud-init.yml
@@ -1,8 +1,4 @@
 #cloud-config
-# This file is an Azure-specific cloud-init configuration file.
-# Upgrade the instance on first boot:
-package_upgrade: true
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -20,4 +16,8 @@ package_upgrade: true
 # limitations under the License.
 #
 #
+# NOTE: do not modify the first line in this file - it is a mandatory
+# header to designate the contents as a cloud-init configuration
 #
+# Upgrade the instance on first boot:
+package_upgrade: true

--- a/ansible/roles/azure/files/cloud-init.yml
+++ b/ansible/roles/azure/files/cloud-init.yml
@@ -1,0 +1,23 @@
+#cloud-config
+# This file is an Azure-specific cloud-init configuration file.
+# Upgrade the instance on first boot:
+package_upgrade: true
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#

--- a/ansible/roles/azure/tasks/create_multiple_vmss.yml
+++ b/ansible/roles/azure/tasks/create_multiple_vmss.yml
@@ -63,6 +63,7 @@
         {%- set _ = data_disks.append({'lun': lun, 'disk_size_gb': item.data_disk_size_gb, 'managed_disk_type': item.data_disk_sku, 'caching': item.data_disk_caching|default('ReadOnly') }) -%}
       {%- endfor -%}
       {{ data_disks }}
+    custom_data: "{{ lookup('file', 'cloud-init.yml') }}"
   with_items:
     - "{{ azure_multiple_vmss_vars.vars_list }}"
   vars:

--- a/ansible/roles/azure/tasks/create_optional_proxy.yml
+++ b/ansible/roles/azure/tasks/create_optional_proxy.yml
@@ -83,6 +83,7 @@
      - lun: 0
        disk_size_gb: 64
        managed_disk_type: "{{ data_disk_sku }}"
+    custom_data: "{{ lookup('file', 'cloud-init.yml') }}"
   vars:
   - image_offer: "{{ azure_proxy_image_reference.split('|')[0] }}"
   - image_publisher: "{{ azure_proxy_image_reference.split('|')[1] }}"

--- a/ansible/roles/azure/tasks/create_vmss.yml
+++ b/ansible/roles/azure/tasks/create_vmss.yml
@@ -66,6 +66,7 @@
       sku: "{{ image_sku if image_sku else omit }}"
       version: "{{ image_version if image_version else omit }}"
     data_disks: "{{ luns_dict if data_disk_count > 0 else omit }}"
+    custom_data: "{{ lookup('file', 'cloud-init.yml') }}"
   vars:
   - image_offer: "{{ azure_image_reference.split('|')[0] }}"
   - image_publisher: "{{ azure_image_reference.split('|')[1] }}"


### PR DESCRIPTION
Define and use a cloud-init config which is then passed to the Azure
instance creation modules as custom data. Currently the only
per-instance configuration specified is to upgrade the existing CentOS
packages on the VM. This provides a Azure-specific solution to a
Azure-specific requirement (as there is not a more recent version
of CentOS 7.9 for Azure). Without this, currently Muchos cannot
be used to setup a cluster on Azure as the CA certificates are outdated
and prevent Ansible from downloading tarballs on the proxy host.