### PR TITLE
Switch unit tests to use nose2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Muchos has unit tests. To run them, first install required packages:
 ```
 The following command runs the unit tests:
 ```
-    nosetests -w lib/
+    nose2 -v -B
 ```
 
 ## Before you submit a PR

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,4 +1,4 @@
 flake8==3.8.0
 ansible-core==2.11.3
 ansible-lint==5.1.2
-nose==1.3.7
+nose2==0.10.0

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -e
-echo "Running nose tests..."
-nosetests -w lib/
-echo "SUCCESS: All Nose tests completed."
+echo "Running nose2 tests..."
+cd lib
+nose2 -v -B
+echo "SUCCESS: All nose2 tests completed."
 echo "Running Ansible-lint..."
+cd ..
 ansible-lint -x no-changed-when,risky-file-permissions,unnamed-task,var-naming
 echo "SUCCESS: Ansible-lint completed."
 echo "Running flake8 to check Python code..."


### PR DESCRIPTION
* Update unit tests to run on [nose2](https://github.com/nose-devs/nose2)
  which replaces the erstwhile nose (no longer maintained).
  nose2 is also compatible with recent Python 3.x releases

* Pin the version of nose2 for stability in CI.