### PR TITLE
Use Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-# This GitHub Actions workflow will prepare a environment with Python 3.6
+# This GitHub Actions workflow will prepare a environment with Python 3.9
 # and the required Python packages, to run the CI tests
 # (Ansible-lint, Flake8 etc.) for Fluo-Muchos.
 # See also:
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.9'
     - name: Install required packages
       run: pip install -r ./lib/requirements.txt
     - name: Install Azure specific Ansible collections

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Check out [Uno] for setting up Accumulo or Fluo on a single machine.
 Muchos requires the following common components for installation and setup:
 
 * Python 3 with a virtual environment setup.
-Create a Python 3 environment and switch to it. (We tested using Python 3.6.8,
+Create a Python 3 environment and switch to it. (The CI tests using Python 3.9,
 but this should work in later versions as well. If you encounter problems,
-please file an issue.)
+please file an issue).
 ```bash
 cd ~
-python3.6 -m venv env
+python3.9 -m venv env
 source env/bin/activate
 ```
 * `ssh-agent` installed and running and ssh-agent forwarding.  Note that this may

--- a/docs/azure-ubuntu-1804.md
+++ b/docs/azure-ubuntu-1804.md
@@ -10,7 +10,7 @@ the following steps can get you on your way.
 # https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
 
 # Install Ansible Azure for Python 3.  The main reason these tips were written
-# was to save you time on the following steps.  Muchos needs Python 3.6 and above.
+# was to save you time on the following steps.  Muchos is tested with Python 3.9 and above.
 # If python-pip and pip were installed and used, those would go against Python 2
 # and would not work.
 sudo apt install python3-pip

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,4 +1,4 @@
-flake8==3.8.0
+flake8==4.0.1
 ansible-core==2.11.3
-ansible-lint==5.1.2
+ansible-lint==5.3.1
 nose2==0.10.0


### PR DESCRIPTION
* Fixes #405. As GitHub Actions does not yet support Python 3.10 for all
  runner environments, we will stay with Python 3.9 for now. The Python 3.9
  end-of-life date of Oct 2025 is adequate for our purposes.

* Upgrade flake8 and ansible-lint packages to sync with new Python version.

* Update docs