### PR TITLE
Add kill and wipe actions for ELK stack

### DIFF
--- a/ansible/kill.yml
+++ b/ansible/kill.yml
@@ -44,3 +44,21 @@
     when: "'swarmmanager' in groups"
   - name: "ensure all processes started by Muchos are killed"
     script: roles/common/files/kill.sh
+
+- hosts: all:!{{ azure_proxy_host }}
+  become: yes
+  tasks:
+  - block:
+    - name: stop kibana
+      service:
+        name: kibana
+        state: stopped
+    - name: stop elasticsearch
+      service:
+        name: elasticsearch
+        state: stopped
+    - name: stop logstash
+      service:
+        name: logstash
+        state: stopped
+    when: "'elkserver' in groups"

--- a/ansible/roles/common/files/kill.sh
+++ b/ansible/roles/common/files/kill.sh
@@ -26,5 +26,10 @@ pkill -9 -f JobHistoryServer
 pkill -9 -f org.apache.spark.deploy.history.HistoryServer
 sudo pkill -9 -f influxdb
 sudo pkill -9 -f grafana-server
+sudo pkill -9 -f kibana
+sudo pkill -9 -f elasticsearch
+sudo pkill -9 -f logstash
+sudo pkill -9 -f filebeat
+sudo screen -wipe
 
 exit 0

--- a/ansible/roles/filebeat/tasks/main.yml
+++ b/ansible/roles/filebeat/tasks/main.yml
@@ -57,5 +57,5 @@
 
 #Run Filebeat
 - name: Run Filebeat in the background
-  command: screen -d -m ./filebeat -e -c filebeat.yml -d "publish"
+  command: screen -d -m filebeat -e -c filebeat.yml -d "publish"
   become: true

--- a/ansible/wipe.yml
+++ b/ansible/wipe.yml
@@ -109,3 +109,83 @@
     retries: 10
     delay: 3
     until: delete_task is success
+
+- hosts: all:!{{ azure_proxy_host }}
+  become: yes
+  tasks:
+  - block:
+    - name: remove kibana
+      yum:
+        name: kibana*
+        state: absent
+    - name: delete kibana rpm
+      file:
+        path: /tmp/{{ kibana_rpm }}
+        state: absent
+        force: yes
+    - name: remove /etc/kibana directory
+      file:
+        path: /etc/kibana
+        state: absent
+        force: yes
+    - name: remove /var/log/kibana directory
+      file:
+        path: /var/log/kibana/
+        state: absent
+        force: yes
+    - name: remove /var/run/kibana directory
+      file:
+        path: /var/run/kibana/
+        state: absent
+        force: yes
+    - name: disable logstash beat
+      command: filebeat modules disable logstash
+      ignore_errors: yes
+    - name: remove filebeat
+      yum:
+        name: filebeat*
+        state: absent
+    - name: delete filebeat rpm
+      file:
+        path: /tmp/{{ filebeat_rpm }}
+        state: absent
+        force: yes
+    - name: delete /etc/filebeat directory
+      file:
+        path: /etc/filebeat/
+        state: absent
+        force: yes
+    - name: remove logstash
+      yum:
+        name: logstash*
+        state: absent
+    - name: delete logstash rpm
+      file:
+        path: /tmp/{{ logstash_rpm }}
+        state: absent
+        force: yes
+    - name: remove etc/logstash directory
+      file:
+        path: /etc/logstash
+        state: absent
+        force: yes
+    - name: remove elasticsearch
+      yum:
+        name: elasticsearch*
+        state: absent
+    - name: delete /etc/elasticsearch directory
+      file:
+        path: /etc/elasticsearch
+        state: absent
+        force: yes
+    - name: delete /var/lib/elasticsearch directory
+      file:
+        path: /var/lib/elasticsearch
+        state: absent
+        force: yes
+    - name: delete elasticsearch rpm
+      file:
+        path: /tmp/{{ elasticsearch_rpm }}
+        state: absent
+        force: yes
+    when: "'elkserver' in groups"


### PR DESCRIPTION
* Fixes #368 by adding kill and wipe support for the elkserver role

* Fix a minor bug in the filebeat Ansible tasks to use the correct path
  to run filebeat in the background.