### PR TITLE
Mitigate Log4Shell issues in ELK stack

### DIFF
--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -82,6 +82,10 @@
     enabled: yes
   become: true
 
+- name: remove jndi plugin from log4j jar to mitigate log4shell
+  shell: zip -q -d /usr/share/elasticsearch/lib/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+  become: true
+
 # Restart Elasticsearch
 - name: Start Elasticsearch
   service:

--- a/ansible/roles/logstash/tasks/main.yml
+++ b/ansible/roles/logstash/tasks/main.yml
@@ -37,6 +37,10 @@
     name: /tmp/{{ logstash_rpm }}
     state: present
 
+- name: remove jndi plugin from log4j jar to mitigate log4shell
+  shell: zip -q -d /usr/share/logstash/logstash-core/lib/jars/log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+  become: true
+
 # Update startup.option file with the new home location.
 - name: Update the startup.option file
   lineinfile:


### PR DESCRIPTION
Fixes #418.

Muchos can be used to deploy an optional `elkserver` role wherein
OSS versions of the ELK stack are deployed (see #338).

Elasticsearch and Logstash are among the external packages deployed
when the `elkserver` role is optionally assigned to hosts in muchos.props.
Both those packages use an older version of log4j2 which is vulnerable
to the following known issues:

https://nvd.nist.gov/vuln/detail/CVE-2021-44228
&
https://nvd.nist.gov/vuln/detail/CVE-2021-45046

ElasticSearch and Logstash and have addressed these
vulnerabilities in their 7.16.2 releases. However, due to licensing
issues the last OSS ELK stack version is 7.10.2, which requires the
removal of the JNDI class for mitigation.

Hence, we mitigate the known vulnerabilities by deleting the JNDI class
from the older log4j2-core JAR deployed by those external components.