### PR TITLE
Update Ansible version and consequent affected files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,12 +40,14 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install required packages
       run: pip install -r ./lib/requirements.txt
+    - name: Install common Ansible collections
+      run: ./scripts/install-ansible-collections
     - name: Install Azure specific Ansible collections
       run: ./scripts/install-ansible-for-azure
     - name: Run Fluo-Muchos CI script

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ also require the creation of SSH public-private [key pair](https://help.github.c
 eval $(ssh-agent -s)
 ssh-add ~/.ssh/id_rsa
 ```
-* Git (current version)
+* Git (current version).
+* Install required Python libraries by executing `pip install -r lib/requirements.txt` command.
+* Install common Ansible collections by executing the [install-ansible-collections](scripts/install-ansible-collections) script.
 
 ### EC2
 

--- a/ansible/accumulo.yml
+++ b/ansible/accumulo.yml
@@ -19,7 +19,7 @@
   tasks:
     - import_tasks: roles/accumulo/tasks/download.yml
       when: download_software
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   roles:
     - accumulo
 - hosts: accumulomaster[0]
@@ -27,7 +27,7 @@
     - import_tasks: roles/accumulo/tasks/init-accumulo.yml
   handlers:
     - import_tasks: roles/accumulo/handlers/init-accumulo.yml
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   tasks:
     - import_tasks: roles/accumulo/tasks/add-adlsgen2.yml
       when: cluster_type == 'azure' and accumulo_version is version('2.0.0','>=') and accumulo_version is version('2.1.0','<') and use_adlsg2
@@ -70,17 +70,17 @@
 - hosts: accumulomaster
   tasks:
     - name: "install and start all the accumulo services using systemd"
+      when: use_systemd
+      become: yes
       block:
         - import_tasks: roles/accumulo/tasks/start-master.yml
         - import_tasks: roles/accumulo/tasks/start-gc.yml
         - import_tasks: roles/accumulo/tasks/start-monitor.yml
-      when: use_systemd
-      become: yes
     - name: "install and start all the accumulo tracer service using systemd"
-      block:
-        - import_tasks: roles/accumulo/tasks/start-tracer.yml
       when: accumulo_version is version('2.0.0','>=') and use_systemd and accumulo_version is version('2.1.0','<')
       become: yes
+      block:
+        - import_tasks: roles/accumulo/tasks/start-tracer.yml
 
 - hosts: workers
   gather_facts: false

--- a/ansible/azure_terminate.yml
+++ b/ansible/azure_terminate.yml
@@ -18,66 +18,66 @@
 ---
 - hosts: localhost
   tasks:
-    - block:
-      - import_tasks: roles/azure/tasks/log_analytics_ws_common.yml
-      - import_tasks: roles/azure/tasks/application_insights_common.yml
-
-      - name: Delete application insights
-        azure_rm_resource:
-           resource_group: "{{ resource_group }}"
-           provider: insights
-           resource_type: components
-           resource_name: "{{ app_insights_name }}"
-           api_version: '2020-02-02'
-           state: absent
-
-      - name: Delete workbook
-        azure_rm_resource:
-           resource_group: "{{ resource_group }}"
-           provider: insights
-           resource_type: workbooks
-           resource_name: "{{ workbook_name }}"
-           api_version: '2020-02-12'
-           state: absent
-        when: workbook_exists
-
-      - name: Delete dashboard
-        azure_rm_resource:
-           resource_group: "{{ resource_group }}"
-           provider: Portal
-           resource_type: dashboards
-           resource_name:  "{{ dashboard_name }}"
-           api_version: '2019-01-01-preview'
-           state: absent
-
-      - name: Delete log analytics workspace
-        azure_rm_resource:
-           resource_group: "{{ resource_group }}"
-           provider: OperationalInsights
-           resource_type: workspaces
-           resource_name: "{{ log_workspace_name }}"
-           api_version: '2015-03-20'
-           state: absent
+    - name: "Tasks for removing Azure specific components"
       when: az_oms_integration_needed
+      block:
+        - import_tasks: roles/azure/tasks/log_analytics_ws_common.yml
+        - import_tasks: roles/azure/tasks/application_insights_common.yml
+
+        - name: Delete application insights
+          azure_rm_resource:
+            resource_group: "{{ resource_group }}"
+            provider: insights
+            resource_type: components
+            resource_name: "{{ app_insights_name }}"
+            api_version: "2020-02-02"
+            state: absent
+
+        - name: Delete workbook
+          azure_rm_resource:
+            resource_group: "{{ resource_group }}"
+            provider: insights
+            resource_type: workbooks
+            resource_name: "{{ workbook_name }}"
+            api_version: "2020-02-12"
+            state: absent
+          when: workbook_exists
+
+        - name: Delete dashboard
+          azure_rm_resource:
+            resource_group: "{{ resource_group }}"
+            provider: Portal
+            resource_type: dashboards
+            resource_name: "{{ dashboard_name }}"
+            api_version: "2019-01-01-preview"
+            state: absent
+
+        - name: Delete log analytics workspace
+          azure_rm_resource:
+            resource_group: "{{ resource_group }}"
+            provider: OperationalInsights
+            resource_type: workspaces
+            resource_name: "{{ log_workspace_name }}"
+            api_version: "2015-03-20"
+            state: absent
 
     - name: Delete User Assigned Identity
       azure_rm_resource:
-         resource_group: "{{ resource_group }}"
-         provider: ManagedIdentity
-         resource_type: userAssignedIdentities
-         resource_name:  "{{ user_assigned_identity if user_assigned_identity else vmss_name + '-ua-msi' }}"
-         api_version: '2018-11-30'
-         state: absent
+        resource_group: "{{ resource_group }}"
+        provider: ManagedIdentity
+        resource_type: userAssignedIdentities
+        resource_name: "{{ user_assigned_identity if user_assigned_identity else vmss_name + '-ua-msi' }}"
+        api_version: "2018-11-30"
+        state: absent
       when: use_adlsg2
 
     - name: Delete ADLS Gen2 storage Account
       azure_rm_storageaccount:
-         resource_group: "{{ resource_group }}"
-         name:  "{{ item.split('@')[1].split('.')[0] }}"
-         force_delete_nonempty: yes
-         state: absent
-      loop:
-         "{{ instance_volumes_adls.split(',') }}"
+        resource_group: "{{ resource_group }}"
+        name: "{{ item.split('@')[1].split('.')[0] }}"
+        force_delete_nonempty: yes
+        state: absent
+      loop: "{{ instance_volumes_adls.split(',') }}"
       when: use_adlsg2
 
     - name: Delete VM Scale Set
@@ -135,7 +135,7 @@
         vnet_facts.virtualnetworks|map(attribute='tags')|map(attribute='deployment_type')|join('') == 'muchos'
 
     - name: Delete the resource group if it is empty
-      azure_rm_resourcegroup:
+      azure.azcollection.azure_rm_resourcegroup:
         name: "{{ resource_group }}"
         state: absent
       retries: 30

--- a/ansible/azure_wipe.yml
+++ b/ansible/azure_wipe.yml
@@ -17,26 +17,24 @@
 
 - hosts: localhost
   tasks:
-  - name: Delete container/Filesystem on ADLS Gen2
-    azure_rm_storageblob:
-      resource_group: "{{ resource_group }}"
-      storage_account_name:  "{{ item.split('@')[1].split('.')[0] }}"
-      container: "{{ item.split('@')[0].split('://')[1] }}"
-      state: absent
-      force: yes
-    loop:
-        "{{ instance_volumes_adls.split(',') }}"
-    when: cluster_type == 'azure' and use_adlsg2
+    - name: Delete container/Filesystem on ADLS Gen2
+      azure_rm_storageblob:
+        resource_group: "{{ resource_group }}"
+        storage_account_name: "{{ item.split('@')[1].split('.')[0] }}"
+        container: "{{ item.split('@')[0].split('://')[1] }}"
+        state: absent
+        force: yes
+      loop: "{{ instance_volumes_adls.split(',') }}"
+      when: cluster_type == 'azure' and use_adlsg2
 
-  - name: Create container/Filesystem on ADLS Gen2
-    azure_rm_storageblob:
-      resource_group: "{{ resource_group }}"
-      storage_account_name:  "{{ item.split('@')[1].split('.')[0] }}"
-      container: "{{ item.split('@')[0].split('://')[1] }}"
-    retries: 20
-    delay: 30
-    register: result
-    until: result is succeeded and (not result.changed or (result.changed and result.container|length > 0))
-    loop:
-      "{{ instance_volumes_adls.split(',')  }}"
-    when: cluster_type == 'azure' and use_adlsg2
+    - name: Create container/Filesystem on ADLS Gen2
+      azure_rm_storageblob:
+        resource_group: "{{ resource_group }}"
+        storage_account_name: "{{ item.split('@')[1].split('.')[0] }}"
+        container: "{{ item.split('@')[0].split('://')[1] }}"
+      retries: 20
+      delay: 30
+      register: result
+      until: result is succeeded and (not result.changed or (result.changed and result.container|length > 0))
+      loop: "{{ instance_volumes_adls.split(',')  }}"
+      when: cluster_type == 'azure' and use_adlsg2

--- a/ansible/common.yml
+++ b/ansible/common.yml
@@ -35,15 +35,16 @@
     - import_tasks: roles/common/tasks/ssh.yml
     - import_tasks: roles/common/tasks/os.yml
 
-    - block:
-      - import_tasks: roles/common/tasks/azure.yml
-      - import_tasks: roles/common/tasks/azure_oms.yml
-        when: az_oms_integration_needed
-      - import_tasks: roles/common/tasks/azure_oms_selinux.yml
-        when: az_oms_integration_needed
-      - import_tasks: roles/common/tasks/azure_application_insights.yml
-        when: az_use_app_insights
+    - name: "Run Azure specific tasks"
       when: cluster_type == 'azure'
+      block:
+        - import_tasks: roles/common/tasks/azure.yml
+        - import_tasks: roles/common/tasks/azure_oms.yml
+          when: az_oms_integration_needed
+        - import_tasks: roles/common/tasks/azure_oms_selinux.yml
+          when: az_oms_integration_needed
+        - import_tasks: roles/common/tasks/azure_application_insights.yml
+          when: az_use_app_insights
 
     - import_tasks: roles/common/tasks/ec2.yml
       when: cluster_type == 'ec2'

--- a/ansible/docker.yml
+++ b/ansible/docker.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   become: yes
   roles:
     - docker

--- a/ansible/elk.yml
+++ b/ansible/elk.yml
@@ -19,7 +19,7 @@
 
 # Playbook to install the ELK stack + Beats
 #
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   roles:
     - { role: elasticsearch }
     - { role: filebeat }

--- a/ansible/hadoop.yml
+++ b/ansible/hadoop.yml
@@ -17,12 +17,12 @@
 
 - hosts: proxy
   tasks:
-  # This is currently needed to run hadoop with Java 11 (see https://github.com/apache/fluo-muchos/issues/266)
-  - name: "Download javax.activation-api for Hadoop 3 when Java 11 is used"
-    command: "{{ maven_home }}/bin/mvn dependency:copy -Dartifact=javax.activation:javax.activation-api:1.2.0 -DoutputDirectory={{ user_home }}/mvn_dep/"
-    when: hadoop_major_version == '3' and java_product_version == 11
+    # This is currently needed to run hadoop with Java 11 (see https://github.com/apache/fluo-muchos/issues/266)
+    - name: "Download javax.activation-api for Hadoop 3 when Java 11 is used"
+      command: "{{ maven_home }}/bin/mvn dependency:copy -Dartifact=javax.activation:javax.activation-api:1.2.0 -DoutputDirectory={{ user_home }}/mvn_dep/"
+      when: hadoop_major_version == '3' and java_product_version == 11
 
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   roles:
     - hadoop
 - hosts: journalnode

--- a/ansible/kill.yml
+++ b/ansible/kill.yml
@@ -18,47 +18,48 @@
 - hosts: mesosmaster
   become: yes
   tasks:
-  - name: "stop mesos-master & marathon"
-    service:
-      name: item
-      state: stopped
-    when: "'mesosmaster' in groups"
-    with_items:
-      - mesos-master
-      - marathon
+    - name: "stop mesos-master & marathon"
+      service:
+        name: item
+        state: stopped
+      when: "'mesosmaster' in groups"
+      with_items:
+        - mesos-master
+        - marathon
 - hosts: workers
   become: yes
   tasks:
-  - name: "stop mesos slaves"
-    service:
-      name: mesos-slave
-      state: stopped
-    when: "'mesosmaster' in groups"
-- hosts: all:!{{ azure_proxy_host }}
+    - name: "stop mesos slaves"
+      service:
+        name: mesos-slave
+        state: stopped
+      when: "'mesosmaster' in groups"
+- hosts: all:!{{ azure_proxy_host|default("") }}
   become: yes
   tasks:
-  - name: "stop docker"
-    service:
-      name: docker
-      state: stopped
-    when: "'swarmmanager' in groups"
-  - name: "ensure all processes started by Muchos are killed"
-    script: roles/common/files/kill.sh
+    - name: "stop docker"
+      service:
+        name: docker
+        state: stopped
+      when: "'swarmmanager' in groups"
+    - name: "ensure all processes started by Muchos are killed"
+      script: roles/common/files/kill.sh
 
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   become: yes
   tasks:
-  - block:
-    - name: stop kibana
-      service:
-        name: kibana
-        state: stopped
-    - name: stop elasticsearch
-      service:
-        name: elasticsearch
-        state: stopped
-    - name: stop logstash
-      service:
-        name: logstash
-        state: stopped
-    when: "'elkserver' in groups"
+    - name: "stop ELK stack services"
+      when: "'elkserver' in groups"
+      block:
+        - name: stop kibana
+          service:
+            name: kibana
+            state: stopped
+        - name: stop elasticsearch
+          service:
+            name: elasticsearch
+            state: stopped
+        - name: stop logstash
+          service:
+            name: logstash
+            state: stopped

--- a/ansible/library/azure_rm_virtualmachinescaleset_nic_list_facts.py
+++ b/ansible/library/azure_rm_virtualmachinescaleset_nic_list_facts.py
@@ -203,7 +203,7 @@ except Exception:
     # This is handled in azure_rm_common
     pass
 
-from ansible.module_utils.azure_rm_common import AzureRMModuleBase, azure_id_to_dict
+from ansible_collections.azure.azcollection.plugins.module_utils.azure_rm_common import AzureRMModuleBase, azure_id_to_dict
 
 
 AZURE_OBJECT_CLASS = 'NetworkInterface'

--- a/ansible/mesos.yml
+++ b/ansible/mesos.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   become: yes
   roles:
     - mesos

--- a/ansible/roles/accumulo/tasks/main.yml
+++ b/ansible/roles/accumulo/tasks/main.yml
@@ -82,7 +82,7 @@
 - name: "Create accumulo log dir"
   file: path={{ worker_data_dirs[0] }}/logs/accumulo state=directory
 - name: "Copy the modified accumulo-cluster script that supports systemd to bin"
-  template: src=accumulo-cluster-systemd dest={{ accumulo_home }}/bin/accumulo-cluster-systemd mode=0755
+  template: src=accumulo-cluster-systemd dest={{ accumulo_home }}/bin/accumulo-cluster-systemd mode="0755"
   when: use_systemd
 - name: "Remove the existing accumulo-service and accumulo-cluster scripts"
   file: path={{ accumulo_home }}/bin/{{ item }} state=absent
@@ -91,5 +91,5 @@
     - accumulo-cluster
   when: use_systemd
 - name: "Create a symlink for accumulo-cluster-systemd"
-  file: src={{ accumulo_home }}/bin/accumulo-cluster-systemd dest={{ accumulo_home }}/bin/accumulo-cluster mode=0755 state=link
+  file: src={{ accumulo_home }}/bin/accumulo-cluster-systemd dest={{ accumulo_home }}/bin/accumulo-cluster mode="0755" state=link
   when: use_systemd

--- a/ansible/roles/accumulo/tasks/start-gc.yml
+++ b/ansible/roles/accumulo/tasks/start-gc.yml
@@ -19,7 +19,7 @@
   template:
     src: roles/accumulo/templates/gc.j2
     dest: "/etc/systemd/system/accumulo-gc.service"
-    mode: 0644
+    mode: "0644"
 
 - name: start accumulo-gc using systemd
   systemd:

--- a/ansible/roles/accumulo/tasks/start-master.yml
+++ b/ansible/roles/accumulo/tasks/start-master.yml
@@ -19,7 +19,7 @@
   template:
     src: roles/accumulo/templates/master.j2
     dest: "/etc/systemd/system/accumulo-master.service"
-    mode: 0644
+    mode: "0644"
 
 - name: start accumulo-master using systemd
   systemd:

--- a/ansible/roles/accumulo/tasks/start-monitor.yml
+++ b/ansible/roles/accumulo/tasks/start-monitor.yml
@@ -19,7 +19,7 @@
   template:
     src: roles/accumulo/templates/monitor.j2
     dest: "/etc/systemd/system/accumulo-monitor.service"
-    mode: 0644
+    mode: "0644"
 
 - name: start accumulo-monitor using systemd
   systemd:

--- a/ansible/roles/accumulo/tasks/start-tracer.yml
+++ b/ansible/roles/accumulo/tasks/start-tracer.yml
@@ -19,7 +19,7 @@
   template:
     src: roles/accumulo/templates/tracer.j2
     dest: "/etc/systemd/system/accumulo-tracer.service"
-    mode: 0644
+    mode: "0644"
 
 - name: start accumulo-tracer using systemd
   systemd:

--- a/ansible/roles/accumulo/tasks/start-tserver.yml
+++ b/ansible/roles/accumulo/tasks/start-tserver.yml
@@ -19,7 +19,7 @@
   template:
     src: roles/accumulo/templates/tserver.j2
     dest: "/etc/systemd/system/accumulo-tserver@.service"
-    mode: 0644
+    mode: "0644"
 
 - name: start accumulo-tserver(s) using systemd
   systemd:

--- a/ansible/roles/azure/tasks/application_insights_common.yml
+++ b/ansible/roles/azure/tasks/application_insights_common.yml
@@ -28,4 +28,4 @@
 
 - name: Set fact for Application Insights name
   set_fact:
-     app_insights_name: "{{ monitor_name.stdout + '-insights' }}"
+    app_insights_name: "{{ monitor_name.stdout + '-insights' }}"

--- a/ansible/roles/azure/tasks/assign_msi_multiple_vmss.yml
+++ b/ansible/roles/azure/tasks/assign_msi_multiple_vmss.yml
@@ -30,11 +30,10 @@
     provider: Compute
     resource_type: virtualMachineScaleSets
     resource_name: "{{ vmss_name }}-{{ item.name_suffix }}"
-    api_version: '2019-03-01'
+    api_version: "2019-03-01"
     body:
-     location: "{{ location }}"
-     identity:
-       type: UserAssigned
-       userAssignedIdentities: "{{ UserAssignedIdentityArr|join('') }}"
-  loop:
-     "{{ azure_multiple_vmss_vars.vars_list }}"
+      location: "{{ location }}"
+      identity:
+        type: UserAssigned
+        userAssignedIdentities: "{{ UserAssignedIdentityArr|join('') }}"
+  loop: "{{ azure_multiple_vmss_vars.vars_list }}"

--- a/ansible/roles/azure/tasks/assign_msi_single_vmss.yml
+++ b/ansible/roles/azure/tasks/assign_msi_single_vmss.yml
@@ -22,9 +22,9 @@
     provider: Compute
     resource_type: virtualMachineScaleSets
     resource_name: "{{ vmss_name }}"
-    api_version: '2019-03-01'
+    api_version: "2019-03-01"
     body:
-     location: "{{ location }}"
-     identity:
-       type: UserAssigned
-       userAssignedIdentities: "{{ UserAssignedIdentityArr|join('') }}"
+      location: "{{ location }}"
+      identity:
+        type: UserAssigned
+        userAssignedIdentities: "{{ UserAssignedIdentityArr|join('') }}"

--- a/ansible/roles/azure/tasks/create_adlsgen2.yml
+++ b/ansible/roles/azure/tasks/create_adlsgen2.yml
@@ -33,7 +33,7 @@
 
 - name: Generate random names for storage account names
   set_fact:
-   StorageAccountName: "{{ StorageAccountMD5.stdout + 99|random(seed=resource_group)|string + 99|random(seed=vmss_name)|string + 9|random(seed=location)|string }}"
+    StorageAccountName: "{{ StorageAccountMD5.stdout + 99|random(seed=resource_group)|string + 99|random(seed=vmss_name)|string + 9|random(seed=location)|string }}"
 
 - name: Initialize instance variables
   set_fact:
@@ -50,25 +50,24 @@
 
 - name: Retrieve sequence end number to get the number of storage accounts
   set_fact:
-     InstanceVolumesEndSequence: "{{ '1' if  instance_volumes_input.split('|')[0].split(',') == ['']  else InstanceVolumesTemp[0]|int }}"
+    InstanceVolumesEndSequence: "{{ '1' if  instance_volumes_input.split('|')[0].split(',') == ['']  else InstanceVolumesTemp[0]|int }}"
 
 - name: Generate names for Storage Accounts
   set_fact:
-     InstanceVolumesAuto: "{{ InstanceVolumesAuto + ['abfss://'+'accumulodata'+'@'+StorageAccountName+item+'.'+InstanceVolumesTemp[1]+'/accumulo'] }}"
+    InstanceVolumesAuto: "{{ InstanceVolumesAuto + ['abfss://'+'accumulodata'+'@'+StorageAccountName+item+'.'+InstanceVolumesTemp[1]+'/accumulo'] }}"
   with_sequence: start=1 end={{ InstanceVolumesEndSequence|int }}
   when: InstanceVolumesTemp[0]|int != 0
 
 - name: Retrieve ABFSS values when specified manually
   set_fact:
-     InstanceVolumesManual: "{{ InstanceVolumesManual +  [ item ] }}"
-  loop:
-    "{{ InstanceVolumesTemp }}"
+    InstanceVolumesManual: "{{ InstanceVolumesManual +  [ item ] }}"
+  loop: "{{ InstanceVolumesTemp }}"
   when: item.split('://')[0] == 'abfss' and  instance_volumes_input.split('|')[0].split(',') ==  ['']
 
 # This is final list of instance volumes
 - name: Assign variables for auto-generation or manual for storage account creation
   set_fact:
-     InstanceVolumes: "{{ InstanceVolumesManual if  instance_volumes_input.split('|')[0].split(',') ==  [''] else InstanceVolumesAuto }}"
+    InstanceVolumes: "{{ InstanceVolumesManual if  instance_volumes_input.split('|')[0].split(',') ==  [''] else InstanceVolumesAuto }}"
 
 - name: Update instance_volumes_adls  in muchos.props
   lineinfile:
@@ -83,18 +82,17 @@
     provider: Storage
     resource_type: storageAccounts
     resource_name: "{{ item.split('@')[1].split('.')[0] }}"
-    api_version: '2019-04-01'
+    api_version: "2019-04-01"
     idempotency: yes
     state: present
     body:
       sku:
-         name: "{{ adls_storage_type }}"
+        name: "{{ adls_storage_type }}"
       kind: StorageV2
       properties:
-         isHnsEnabled: yes
-      location:  "{{ location }}"
-  loop:
-      "{{ InstanceVolumes }}"
+        isHnsEnabled: yes
+      location: "{{ location }}"
+  loop: "{{ InstanceVolumes }}"
 
 # Creating User Assigned identity with vmss_name suffixed by ua-msi if not specified in muchos.props
 # Not registering variable because user identity values are not visible immediately
@@ -104,7 +102,7 @@
     provider: ManagedIdentity
     resource_type: userAssignedIdentities
     resource_name: "{{ user_assigned_identity if user_assigned_identity else vmss_name + '-ua-msi' }}"
-    api_version: '2018-11-30'
+    api_version: "2018-11-30"
     idempotency: yes
     state: present
     body:
@@ -117,11 +115,11 @@
     provider: ManagedIdentity
     resource_type: userAssignedIdentities
     resource_name: "{{ user_assigned_identity if user_assigned_identity else vmss_name + '-ua-msi' }}"
-    api_version: '2018-11-30'
+    api_version: "2018-11-30"
   register: UserAssignedIdentityInfo
   retries: 20
   delay: 15
-  until:  UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='principalId')|join('') is defined
+  until: UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='principalId')|join('') is defined
 
 - name: Update principal_id in muchos.props
   lineinfile:
@@ -132,29 +130,28 @@
 # This will be used to assign the MSI for VMSS
 - name: Format User Assigned Identity for API
   set_fact:
-    UserAssignedIdentityArr: "{{ UserAssignedIdentityInfo.response|default({})|map(attribute='id')|map('regex_replace','^(.*)$','{\"\\1\":{}}')|list }}" # noqa 206
+    UserAssignedIdentityArr: "{{ UserAssignedIdentityInfo.response|default({})|map(attribute='id')|map('regex_replace','^(.*)$','{\"\\1\":{}}')|list }}"
 
 # Retrieve facts about role assignment
 - name: Get role definition id for "Storage Blob Data Owner"
   azure_rm_resource_info:
     resource_group: "{{ resource_group }}"
     provider: Authorization
-    resource_type:  roleDefinitions
-    resource_name:  b7e6dc6d-f1e8-4753-8033-0f276bb0955b
-    api_version: '2015-07-01'
+    resource_type: roleDefinitions
+    resource_name: b7e6dc6d-f1e8-4753-8033-0f276bb0955b
+    api_version: "2015-07-01"
   register: RoleDefinitionInfo
 
 # Retrieve storage account information
 - name: Check if the storage accounts are visible
   azure_rm_storageaccount_info:
-        resource_group: "{{ resource_group }}"
-        name:   "{{ item.split('@')[1].split('.')[0] }}"
+    resource_group: "{{ resource_group }}"
+    name: "{{ item.split('@')[1].split('.')[0] }}"
   register: StorageAccountsInfo
   retries: 20
   delay: 15
   until: StorageAccountsInfo.storageaccounts | map(attribute='id') | join('') | length > 0
-  loop:
-     "{{ InstanceVolumes }}"
+  loop: "{{ InstanceVolumes }}"
 
 # Retrieve storage accounts id  created; these are used for account assignments
 - name: Get the id of storage accounts created
@@ -162,52 +159,48 @@
     StorageAccountsId: "{{ StorageAccountsInfo.results | sum(attribute='storageaccounts', start=[]) | map(attribute='id') | list | unique }}"
 
 # Adding this module since role assignment fails if it already exists
-- name:  Get facts about role assignment
+- name: Get facts about role assignment
   azure_rm_roleassignment_info:
-     scope: "{{ item }}"
-     assignee: "{{ UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='principalId')|list|join('') }}"
-     role_definition_id: "{{ RoleDefinitionInfo.response|map(attribute='id')|list|join('') }}"
+    scope: "{{ item }}"
+    assignee: "{{ UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='principalId')|list|join('') }}"
+    role_definition_id: "{{ RoleDefinitionInfo.response|map(attribute='id')|list|join('') }}"
   register: RoleAssignmentResults
   retries: 20
   delay: 15
-  until:  UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='principalId')|join('') is  defined and  RoleDefinitionInfo.response|map(attribute='id')|join('') is defined
-  loop:
-    "{{ StorageAccountsId }}"
+  until: UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='principalId')|join('') is  defined and  RoleDefinitionInfo.response|map(attribute='id')|join('') is defined
+  loop: "{{ StorageAccountsId }}"
 
 - name: Set fact for getting storage accounts that have assigned roles
   set_fact:
     StorageAccountRoles: "{{ item|map(attribute='scope')|list|unique }}"
   no_log: True
-  loop:
-      "{{ RoleAssignmentResults.results|map(attribute='roleassignments')|list }}"
+  loop: "{{ RoleAssignmentResults.results|map(attribute='roleassignments')|list }}"
 
 # This retry logic is needed due to race condition between storage account create complete and role assignment
 - name: Create a role assignment
   azure_rm_roleassignment:
-     scope: "{{ item }}"
-     assignee_object_id: "{{ UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='principalId')|list|join('') }}"
-     role_definition_id: "{{ RoleDefinitionInfo.response|map(attribute='id')|list|join('') }}"
-     state: present
+    scope: "{{ item }}"
+    assignee_object_id: "{{ UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='principalId')|list|join('') }}"
+    role_definition_id: "{{ RoleDefinitionInfo.response|map(attribute='id')|list|join('') }}"
+    state: present
   retries: 30
   delay: 15
   register: roleassignresult
   until: roleassignresult is succeeded
-  loop:
-     "{{ StorageAccountsId }}"
+  loop: "{{ StorageAccountsId }}"
   when: item  not in StorageAccountRoles
 
 # This retry logic is needed due to race condition between storage account creation and creating filesystem
 - name: Create container/Filesystem on ADLS Gen2
   azure_rm_storageblob:
     resource_group: "{{ resource_group }}"
-    storage_account_name:  "{{ item.split('@')[1].split('.')[0] }}"
+    storage_account_name: "{{ item.split('@')[1].split('.')[0] }}"
     container: "{{ item.split('@')[0].split('://')[1] }}"
   retries: 20
   delay: 30
   register: createfsresult
   until: createfsresult is succeeded and ((not createfsresult.changed) or (createfsresult.changed and createfsresult.container|length > 0))
-  loop:
-    "{{ InstanceVolumes }}"
+  loop: "{{ InstanceVolumes }}"
 
 # Retrieve tenantId  for core-site.xml
 - name: Update tenantId in muchos.props
@@ -222,4 +215,3 @@
     path: "{{ deploy_path }}/conf/muchos.props"
     regexp: '^azure_client_id\s*=\s*|^[#]azure_client_id\s*=\s*'
     line: "azure_client_id = {{ UserAssignedIdentityInfo.response|map(attribute='properties')|map(attribute='clientId')|list|join('') }}"
-

--- a/ansible/roles/azure/tasks/create_application_insights.yml
+++ b/ansible/roles/azure/tasks/create_application_insights.yml
@@ -34,14 +34,14 @@
     idempotency: yes
     state: present
     body:
-      location:  "{{ location }}"
+      location: "{{ location }}"
       kind: java
       properties:
-         ApplicationId: "{{ app_insights_name }}"
-         Application_Type: other
-         Flow_Type: Bluefield
-         Request_Source: rest
-         WorkspaceResourceId: "{{ az_logs_resource_id if az_logs_resource_id else az_logs_ws_resource_id }}"
+        ApplicationId: "{{ app_insights_name }}"
+        Application_Type: other
+        Flow_Type: Bluefield
+        Request_Source: rest
+        WorkspaceResourceId: "{{ az_logs_resource_id if az_logs_resource_id else az_logs_ws_resource_id }}"
   register: app_insights
 
 - name: Update az_appinsights_connection_string in muchos.props

--- a/ansible/roles/azure/tasks/create_common_resources.yml
+++ b/ansible/roles/azure/tasks/create_common_resources.yml
@@ -26,15 +26,15 @@
 # SECTION 1: Create Azure RG, network and subnet
 #
 - name: Create a resource group
-  azure_rm_resourcegroup:
+  azure.azcollection.azure_rm_resourcegroup:
     name: "{{ resource_group }}"
     location: "{{ location }}"
     tags:
-        deployment_type: muchos
-        application: accumulo
+      deployment_type: muchos
+      application: accumulo
 
 - name: Ensure that the resource group is available
-  azure_rm_resourcegroup_info:
+  azure.azcollection.azure_rm_resourcegroup_info:
     name: "{{ resource_group }}"
   retries: 5
   delay: 3
@@ -42,20 +42,20 @@
   until: resource_group_facts.resourcegroups is defined and resource_group_facts.resourcegroups|map(attribute='name')|join('') is defined and resource_group_facts.resourcegroups|map(attribute='properties')|map(attribute='provisioningState')|join('') == "Succeeded"
 
 - debug:
-   msg: "Name of resource group created: {{ resource_group_facts.resourcegroups|map(attribute='name')|join('') }}"
+    msg: "Name of resource group created: {{ resource_group_facts.resourcegroups|map(attribute='name')|join('') }}"
 
 - debug:
-   msg: "Provisioning state of {{ resource_group }} is {{ resource_group_facts.resourcegroups|map(attribute='properties')|map(attribute='provisioningState')|join('') }}"
+    msg: "Provisioning state of {{ resource_group }} is {{ resource_group_facts.resourcegroups|map(attribute='properties')|map(attribute='provisioningState')|join('') }}"
 
 - name: Create a virtual network
   azure_rm_virtualnetwork:
     resource_group: "{{ resource_group }}"
     name: "{{ vnet }}"
     address_prefixes_cidr:
-        - "{{ vnet_cidr }}"
+      - "{{ vnet_cidr }}"
     tags:
-        deployment_type: muchos
-        application: accumulo
+      deployment_type: muchos
+      application: accumulo
 
 - name: Create a subnet
   azure_rm_subnet:

--- a/ansible/roles/azure/tasks/create_log_analytics_ws.yml
+++ b/ansible/roles/azure/tasks/create_log_analytics_ws.yml
@@ -32,8 +32,8 @@
     state: present
     location: "{{ location }}"
     parameters:
-       la-workspace-name:
-           value: "{{ log_workspace_name }}"
+      la-workspace-name:
+        value: "{{ log_workspace_name }}"
     template: "{{ lookup('file', 'roles/azure/templates/azureDeployLinuxCounters.json') }}"
 
 - name: Gather information about log analytics workspace
@@ -70,14 +70,14 @@
     path: "{{ deploy_path }}/conf/muchos.props"
     regexp: '^az_logs_id\s*=\s*|^[#]az_logs_id\s*=\s*'
     line: "az_logs_id = {{ az_logs_ws_id }}"
-    insertafter: '^az_logs_resource_id'
+    insertafter: "^az_logs_resource_id"
 
 - name: Update az_logs_key in muchos.props
   lineinfile:
     path: "{{ deploy_path }}/conf/muchos.props"
     regexp: '^az_logs_key\s*=\s*|^[#]az_logs_key\s*=\s*'
     line: "az_logs_key = {{ az_logs_ws_key }}"
-    insertafter: '^az_logs_id'
+    insertafter: "^az_logs_id"
 
 - name: Create Dashboard
   azure_rm_deployment:
@@ -85,10 +85,10 @@
     state: present
     location: "{{ location }}"
     parameters:
-       LogAnalyticsWorkspaceName:
-          value: "{{ log_workspace_name }}"
-       DashboardName:
-          value: "{{ dashboard_name }}"
+      LogAnalyticsWorkspaceName:
+        value: "{{ log_workspace_name }}"
+      DashboardName:
+        value: "{{ dashboard_name }}"
     template: "{{ lookup('file', 'roles/azure/templates/dashboardTemplate.json') }}"
   when: az_oms_integration_needed and not dashboard_exists
 
@@ -98,9 +98,9 @@
     state: present
     location: "{{ location }}"
     parameters:
-       LogAnalyticsWorkspaceName:
-          value: "{{ log_workspace_name }}"
-       workbookDisplayName:
-          value: "{{ workbook_name }}"
+      LogAnalyticsWorkspaceName:
+        value: "{{ log_workspace_name }}"
+      workbookDisplayName:
+        value: "{{ workbook_name }}"
     template: "{{ lookup('file', 'roles/azure/templates/workbookTemplate.json') }}"
   when: az_oms_integration_needed and not workbook_exists

--- a/ansible/roles/azure/tasks/create_multiple_vmss.yml
+++ b/ansible/roles/azure/tasks/create_multiple_vmss.yml
@@ -54,8 +54,8 @@
     image:
       offer: "{{ image_offer if image_offer else omit }}"
       publisher: "{{ image_publisher if image_publisher else omit }}"
-      sku:  "{{ image_sku if image_sku else omit }}"
-      version:  "{{ image_version if image_version else omit }}"
+      sku: "{{ image_sku if image_sku else omit }}"
+      version: "{{ image_version if image_version else omit }}"
       id: "{{ image_id if image_id else omit }}"
     data_disks: |
       {%- set data_disks = [] -%}
@@ -67,13 +67,13 @@
   with_items:
     - "{{ azure_multiple_vmss_vars.vars_list }}"
   vars:
-  - image_offer: "{{ azure_image_reference.split('|')[0] }}"
-  - image_publisher: "{{ azure_image_reference.split('|')[1] }}"
-  - image_sku: "{{ azure_image_reference.split('|')[2] }}"
-  - image_version: "{{ azure_image_reference.split('|')[3] }}"
-  - image_id: "{{ azure_image_reference.split('|')[4] }}"
-  - accnet_capable: "{{ True if item.sku in accnet_capable_skus else False }}"
-  - osdisk_sku: "{{ 'Premium_LRS' if item.sku in premiumio_capable_skus else 'Standard_LRS' }}"
+    image_offer: "{{ azure_image_reference.split('|')[0] }}"
+    image_publisher: "{{ azure_image_reference.split('|')[1] }}"
+    image_sku: "{{ azure_image_reference.split('|')[2] }}"
+    image_version: "{{ azure_image_reference.split('|')[3] }}"
+    image_id: "{{ azure_image_reference.split('|')[4] }}"
+    accnet_capable: "{{ True if item.sku in accnet_capable_skus else False }}"
+    osdisk_sku: "{{ 'Premium_LRS' if item.sku in premiumio_capable_skus else 'Standard_LRS' }}"
   register: _create_clusters
   async: 600
   poll: 0
@@ -98,7 +98,7 @@
   async: 600
   poll: 0
 
-- name: Get VMSS nic list
+- name: "Get VMSS nic list"
   azure_rm_virtualmachinescaleset_nic_list_facts:
     resource_group: "{{ resource_group }}"
     vmss_name: "{{ vmss_name }}-{{ item.name_suffix }}"
@@ -154,21 +154,21 @@
 
 - name: Ensures hosts sub-dir exists
   file:
-     path: "{{ deploy_path }}/conf/hosts/"
-     state: directory
-     recurse: yes
+    path: "{{ deploy_path }}/conf/hosts/"
+    state: directory
+    recurse: yes
 
 - name: Ensures host_vars sub-dir exists
   file:
-     path: "{{ deploy_path }}/ansible/host_vars/"
-     state: directory
-     recurse: yes
+    path: "{{ deploy_path }}/ansible/host_vars/"
+    state: directory
+    recurse: yes
 
 - name: Write hosts file
   template:
     src: hostname_ip_mappings.j2
     dest: "{{ deploy_path }}/conf/hosts/{{ vmss_name }}"
-    mode: 0644
+    mode: "0644"
 
 - name: Get vmss to host map
   set_fact:
@@ -226,5 +226,3 @@
     regexp: '^proxy_hostname\s*=\s*'
     line: "proxy_hostname = {{ vmss_host_pairs[0].value }}"
   when: not (azure_proxy_host is defined and azure_proxy_host and azure_proxy_host != None)
-
-

--- a/ansible/roles/azure/tasks/create_optional_proxy.yml
+++ b/ansible/roles/azure/tasks/create_optional_proxy.yml
@@ -60,7 +60,13 @@
     enable_accelerated_networking: "{{ True if azure_proxy_host_vm_sku in accnet_capable_skus else False }}"
   when: azure_proxy_host is defined and azure_proxy_host and azure_proxy_host != None
 
-- name: Create azure proxy virtual machine
+- name: Create azure proxy virtual machine # noqa schema[tasks]
+  vars:
+    image_offer: "{{ azure_proxy_image_reference.split('|')[0] }}"
+    image_publisher: "{{ azure_proxy_image_reference.split('|')[1] }}"
+    image_sku: "{{ azure_proxy_image_reference.split('|')[2] }}"
+    image_version: "{{ azure_proxy_image_reference.split('|')[3] }}"
+    osdisk_sku: "{{ 'Premium_LRS' if azure_proxy_host_vm_sku in premiumio_capable_skus else 'Standard_LRS' }}"
   azure_rm_virtualmachine:
     resource_group: "{{ resource_group }}"
     name: "{{ azure_proxy_host }}"
@@ -80,14 +86,8 @@
       version: "{{ image_version if image_version else omit }}"
     managed_disk_type: "{{ osdisk_sku }}"
     data_disks:
-     - lun: 0
-       disk_size_gb: 64
-       managed_disk_type: "{{ data_disk_sku }}"
+      - lun: 0
+        disk_size_gb: 64
+        managed_disk_type: "{{ data_disk_sku }}"
     custom_data: "{{ lookup('file', 'cloud-init.yml') }}"
-  vars:
-  - image_offer: "{{ azure_proxy_image_reference.split('|')[0] }}"
-  - image_publisher: "{{ azure_proxy_image_reference.split('|')[1] }}"
-  - image_sku: "{{ azure_proxy_image_reference.split('|')[2] }}"
-  - image_version: "{{ azure_proxy_image_reference.split('|')[3] }}"
-  - osdisk_sku: "{{ 'Premium_LRS' if azure_proxy_host_vm_sku in premiumio_capable_skus else 'Standard_LRS' }}"
   when: azure_proxy_host is defined and azure_proxy_host and azure_proxy_host != None

--- a/ansible/roles/azure/tasks/create_vmss.yml
+++ b/ansible/roles/azure/tasks/create_vmss.yml
@@ -1,5 +1,4 @@
 ---
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -68,12 +67,12 @@
     data_disks: "{{ luns_dict if data_disk_count > 0 else omit }}"
     custom_data: "{{ lookup('file', 'cloud-init.yml') }}"
   vars:
-  - image_offer: "{{ azure_image_reference.split('|')[0] }}"
-  - image_publisher: "{{ azure_image_reference.split('|')[1] }}"
-  - image_sku: "{{ azure_image_reference.split('|')[2] }}"
-  - image_version: "{{ azure_image_reference.split('|')[3] }}"
-  - accnet_capable: "{{ True if vm_sku in accnet_capable_skus else False }}"
-  - osdisk_sku: "{{ 'Premium_LRS' if vm_sku in premiumio_capable_skus else 'Standard_LRS' }}"
+    image_offer: "{{ azure_image_reference.split('|')[0] }}"
+    image_publisher: "{{ azure_image_reference.split('|')[1] }}"
+    image_sku: "{{ azure_image_reference.split('|')[2] }}"
+    image_version: "{{ azure_image_reference.split('|')[3] }}"
+    accnet_capable: "{{ True if vm_sku in accnet_capable_skus else False }}"
+    osdisk_sku: "{{ 'Premium_LRS' if vm_sku in premiumio_capable_skus else 'Standard_LRS' }}"
   tags: create_vmss
 
 # SECTION 4: Automatically populate entries in the hosts file and in the muchos.props file, based on the VMSS node details
@@ -90,11 +89,11 @@
 
 - name: Ensures host_vars sub-dir exists
   file:
-     path: "{{ deploy_path }}/ansible/host_vars/"
-     state: directory
-     recurse: yes
+    path: "{{ deploy_path }}/ansible/host_vars/"
+    state: directory
+    recurse: yes
 
-- name: Get VMSS nic list
+- name: "Get VMSS nic list"
   azure_rm_virtualmachinescaleset_nic_list_facts:
     resource_group: "{{ resource_group }}"
     vmss_name: "{{ vmss_name }}"
@@ -124,15 +123,15 @@
 
 - name: Ensures hosts sub-dir exists
   file:
-     path: "{{ deploy_path }}/conf/hosts/"
-     state: directory
-     recurse: yes
+    path: "{{ deploy_path }}/conf/hosts/"
+    state: directory
+    recurse: yes
 
 - name: Write hosts file
   template:
     src: hostname_ip_mappings.j2
     dest: "{{ deploy_path }}/conf/hosts/{{ vmss_name }}"
-    mode: 0644
+    mode: "0644"
 
 - name: Clear section
   community.general.ini_file:
@@ -154,41 +153,43 @@
     line: "{{ azure_proxy_host }} = client"
   when: azure_proxy_host is defined and azure_proxy_host and azure_proxy_host != None
 
-- block:
-  - name: Assign Accumulo master, HDFS components to the first node of the cluster
-    lineinfile:
-      path: "{{ deploy_path }}/conf/muchos.props"
-      line: "{{ hostnames[0] }} = namenode,resourcemanager,accumulomaster,zookeeper"
-  - name: Assign metrics to the second node of the cluster
-    lineinfile:
-      path: "{{ deploy_path }}/conf/muchos.props"
-      line: "{{ hostnames[1] }} = metrics"
-  - name: Add worker nodes to muchos.props
-    lineinfile:
-      path: "{{ deploy_path }}/conf/muchos.props"
-      line: "{{ item }} = worker"
-    with_items: "{{ hostnames | json_query('[2:]') }}"
+- name: "Tasks for writing out muchos.props for non-HA HDFS"
   when: not hdfs_ha
+  block:
+    - name: Assign Accumulo master, HDFS components to the first node of the cluster
+      lineinfile:
+        path: "{{ deploy_path }}/conf/muchos.props"
+        line: "{{ hostnames[0] }} = namenode,resourcemanager,accumulomaster,zookeeper"
+    - name: Assign metrics to the second node of the cluster
+      lineinfile:
+        path: "{{ deploy_path }}/conf/muchos.props"
+        line: "{{ hostnames[1] }} = metrics"
+    - name: Add worker nodes to muchos.props
+      lineinfile:
+        path: "{{ deploy_path }}/conf/muchos.props"
+        line: "{{ item }} = worker"
+      with_items: "{{ hostnames | json_query('[2:]') }}"
 
-- block:
-  - name: Assign Accumulo master, HDFS HA components cluster roles to the first node of the cluster
-    lineinfile:
-      path: "{{ deploy_path }}/conf/muchos.props"
-      line: "{{ hostnames[0] }} = namenode,resourcemanager,accumulomaster,zookeeper,journalnode,zkfc"
-  - name: Assign Accumulo master, HDFS HA components cluster roles to the second node of the cluster
-    lineinfile:
-      path: "{{ deploy_path }}/conf/muchos.props"
-      line: "{{ hostnames[1] }} = zookeeper,metrics,journalnode,namenode,zkfc,accumulomaster,resourcemanager"
-  - name: Assign HDFS HA components cluster roles to the third node of the cluster
-    lineinfile:
-      path: "{{ deploy_path }}/conf/muchos.props"
-      line: "{{ hostnames[2] }} = journalnode,zookeeper"
-  - name: Add worker nodes to muchos.props
-    lineinfile:
-      path: "{{ deploy_path }}/conf/muchos.props"
-      line: "{{ item }} = worker"
-    with_items: "{{ hostnames | json_query('[3:]') }}"
+- name: "Tasks for writing out muchos.props for HA HDFS"
   when: hdfs_ha
+  block:
+    - name: Assign Accumulo master, HDFS HA components cluster roles to the first node of the cluster
+      lineinfile:
+        path: "{{ deploy_path }}/conf/muchos.props"
+        line: "{{ hostnames[0] }} = namenode,resourcemanager,accumulomaster,zookeeper,journalnode,zkfc"
+    - name: Assign Accumulo master, HDFS HA components cluster roles to the second node of the cluster
+      lineinfile:
+        path: "{{ deploy_path }}/conf/muchos.props"
+        line: "{{ hostnames[1] }} = zookeeper,metrics,journalnode,namenode,zkfc,accumulomaster,resourcemanager"
+    - name: Assign HDFS HA components cluster roles to the third node of the cluster
+      lineinfile:
+        path: "{{ deploy_path }}/conf/muchos.props"
+        line: "{{ hostnames[2] }} = journalnode,zookeeper"
+    - name: Add worker nodes to muchos.props
+      lineinfile:
+        path: "{{ deploy_path }}/conf/muchos.props"
+        line: "{{ item }} = worker"
+      with_items: "{{ hostnames | json_query('[3:]') }}"
 
 - name: Change proxy hostname to azure proxy host in muchos.props
   lineinfile:

--- a/ansible/roles/azure/tasks/log_analytics_ws_common.yml
+++ b/ansible/roles/azure/tasks/log_analytics_ws_common.yml
@@ -28,11 +28,11 @@
 
 - name: Set name for log analytics workspace
   set_fact:
-     log_workspace_name: "{{ monitor_name.stdout + '-la' }}"
+    log_workspace_name: "{{ monitor_name.stdout + '-la' }}"
 
 - name: Set name for dashboard
   set_fact:
-     dashboard_name: "{{ monitor_name.stdout + '-db' }}"
+    dashboard_name: "{{ monitor_name.stdout + '-db' }}"
 
 - name: Set display name for workbook
   set_fact:

--- a/ansible/roles/common/tasks/azure.yml
+++ b/ansible/roles/common/tasks/azure.yml
@@ -69,6 +69,6 @@
     fstype: cifs
     src: "{{ azure_fileshare }}"
     path: "{{ azure_fileshare_mount }}"
-    opts: vers=3.0,username={{ azure_fileshare_username }},password={{ azure_fileshare_password }},dir_mode=0777,file_mode=0777,serverino
+    opts: vers=3.0,username={{ azure_fileshare_username }},password={{ azure_fileshare_password }},dir_mode="0777",file_mode="0777",serverino
     state: mounted
   when: azure_fileshare_mount is defined and azure_fileshare_mount and azure_fileshare_mount != None

--- a/ansible/roles/common/tasks/azure_application_insights.yml
+++ b/ansible/roles/common/tasks/azure_application_insights.yml
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 - name: "create application insights dir"
-  file: state=directory mode=0755 path={{ az_app_insights_home }} 
+  file: state=directory mode="0755" path={{ az_app_insights_home }}
 - name: "copy application insights agent jar"
-  copy: src={{ tarballs_dir }}/appinsights-agent.jar dest={{ az_app_insights_home }}/appinsights-agent.jar mode=0644
+  copy: src={{ tarballs_dir }}/appinsights-agent.jar dest={{ az_app_insights_home }}/appinsights-agent.jar mode="0644"
 - name: "copy application insights configuration"
-  template: src=applicationinsights.json dest={{ az_app_insights_home }}/applicationinsights.json mode=0644
+  template: src=applicationinsights.json dest={{ az_app_insights_home }}/applicationinsights.json mode="0644"

--- a/ansible/roles/common/tasks/hosts.yml
+++ b/ansible/roles/common/tasks/hosts.yml
@@ -18,4 +18,4 @@
 - name: "ensure hostname is correct"
   hostname: name={{ inventory_hostname }}
 - name: "ensure /etc/hosts is correct"
-  copy: src=/etc/etc_hosts dest=/etc/hosts owner=root group=root mode=0644
+  copy: src=/etc/etc_hosts dest=/etc/hosts owner=root group=root mode="0644"

--- a/ansible/roles/common/tasks/os.yml
+++ b/ansible/roles/common/tasks/os.yml
@@ -28,7 +28,7 @@
   sysctl: name=vm.zone_reclaim_mode value=1
   when: cluster_type == 'azure' or cluster_type == 'ec2'
 
-# The TCP/IP setting below has been added based on performance testing done 
+# The TCP/IP setting below has been added based on performance testing done
 # with Microsoft Azure based clusters. For more details refer to
 # https://access.redhat.com/solutions/30453
 - name: "set net.core.somaxconn=2048"
@@ -40,10 +40,10 @@
 - name: "copy new limits.conf"
   copy: src=roles/common/files/limits.conf dest=/etc/security/limits.conf
 - name: "configure user shell"
-  template: src=roles/common/templates/{{ item }} dest=/home/{{ cluster_user }}/.{{ item }} owner={{ cluster_user }} group={{ cluster_group }} mode=0644
+  template: src=roles/common/templates/{{ item }} dest=/home/{{ cluster_user }}/.{{ item }} owner={{ cluster_user }} group={{ cluster_group }} mode="0644"
   with_items:
     - bashrc
     - bash_profile
     - vimrc
 - name: "configure root shell"
-  template: src=roles/common/templates/root_bashrc dest=/root/.bashrc mode=0644
+  template: src=roles/common/templates/root_bashrc dest=/root/.bashrc mode="0644"

--- a/ansible/roles/common/tasks/ssh.yml
+++ b/ansible/roles/common/tasks/ssh.yml
@@ -20,10 +20,10 @@
 - name: "copy cluster private key to all nodes"
   copy: src=/home/{{ cluster_user }}/.ssh/id_rsa dest=/home/{{ cluster_user }}/.ssh/id_rsa owner={{ cluster_user }} group={{ cluster_group }} mode=0600
 - name: "copy cluster public key to all nodes"
-  copy: src=/home/{{ cluster_user }}/.ssh/id_rsa.pub dest=/home/{{ cluster_user }}/.ssh/id_rsa.pub owner={{ cluster_user }} group={{ cluster_group }} mode=0644
+  copy: src=/home/{{ cluster_user }}/.ssh/id_rsa.pub dest=/home/{{ cluster_user }}/.ssh/id_rsa.pub owner={{ cluster_user }} group={{ cluster_group }} mode="0644"
 - name: "add cluster user to ~/.ssh/authorized_keys"
-  authorized_key: user={{ cluster_user }} key="{{ lookup('file', '/home/' + cluster_user + '/.ssh/id_rsa.pub') }}"
+  ansible.posix.authorized_key: user={{ cluster_user }} key="{{ lookup('file', '/home/' + cluster_user + '/.ssh/id_rsa.pub') }}"
 - name: "add conf/keys to ~/.ssh/authorized_keys"
-  authorized_key: user={{ cluster_user }} key="{{ lookup('file', 'conf/keys') }}"
+  ansible.posix.authorized_key: user={{ cluster_user }} key="{{ lookup('file', 'conf/keys') }}"
 - name: "set ssh config"
   copy: src=roles/common/files/ssh_config dest=/home/{{ cluster_user }}/.ssh/config owner={{ cluster_user }} group={{ cluster_group }} mode=0600

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -20,9 +20,9 @@
     name: "{{ packages }}"
   vars:
     packages:
-    - yum-utils
-    - device-mapper-persistent-data
-    - lvm2
+      - yum-utils
+      - device-mapper-persistent-data
+      - lvm2
 - name: add docker repo
   yum_repository:
     name: docker-ce-stable
@@ -37,13 +37,13 @@
   file:
     path: "{{ default_data_dirs[0] }}/docker"
     state: directory
-    mode: 0755
+    mode: "0755"
 - name: link /var/lib/docker
   file:
     src: "{{ default_data_dirs[0] }}/docker"
     dest: /var/lib/docker
     state: link
-- name: "add {{ cluster_user }} to docker group"
+- name: "add cluster_user to docker group"
   user:
     name: "{{ cluster_user }}"
     groups: docker

--- a/ansible/roles/filebeat/tasks/main.yml
+++ b/ansible/roles/filebeat/tasks/main.yml
@@ -28,14 +28,14 @@
     checksum: "{{ filebeat_checksum }}"
     force: no
 
-  #Install filebeat"
+# Install filebeat"
 - name: "Install filebeat rpm"
   become: true
   yum:
     name: /tmp/{{ filebeat_rpm }}
     state: present
 
-#Configure Filebeat yml file
+# Configure Filebeat yml file
 
 - name: Copy filebeat.yml to /etc
   template:
@@ -55,7 +55,7 @@
   command: filebeat modules enable logstash
   become: true
 
-#Run Filebeat
+# Run Filebeat
 - name: Run Filebeat in the background
   command: screen -d -m filebeat -e -c filebeat.yml -d "publish"
   become: true

--- a/ansible/roles/hadoop/tasks/main.yml
+++ b/ansible/roles/hadoop/tasks/main.yml
@@ -38,7 +38,7 @@
 
 # This is currently needed to run hadoop with Java 11 (see https://github.com/apache/fluo-muchos/issues/266)
 - name: "Copy javax.activation-api (when Hadoop 3 and Java 11 are used)"
-  synchronize: src={{ user_home }}/mvn_dep/ dest={{ hadoop_home }}/share/hadoop/common/lib/
+  ansible.posix.synchronize: src={{ user_home }}/mvn_dep/ dest={{ hadoop_home }}/share/hadoop/common/lib/
   when: hadoop_major_version == '3' and java_product_version == 11
 
 - name: "setup hadoop short circuit socket dir"

--- a/ansible/roles/kibana/tasks/main.yml
+++ b/ansible/roles/kibana/tasks/main.yml
@@ -16,12 +16,7 @@
 # limitations under the License.
 #
 
-
-# Installing Kibana
-#
-
 # Add the Kibana yum repo.
-
 - name: "download kibana rpm"
   get_url:
   args:
@@ -30,8 +25,7 @@
     checksum: "{{ kibana_checksum }}"
     force: no
 
-    #Install kibana
-
+# Install kibana
 - name: "ensure kibana is installed"
   become: true
   yum:
@@ -39,7 +33,6 @@
     state: present
 
 # Configurations
-
 - name: Updating the config file to allow outside access
   lineinfile:
     destfile: /etc/kibana/kibana.yml
@@ -103,7 +96,7 @@
     path: /var/run/kibana/
     state: directory
     recurse: yes
-    mode: 0777
+    mode: "0777"
     owner: kibana
 
 # Make kibana folder pid
@@ -112,11 +105,10 @@
   file:
     path: /var/run/kibana/kibana.pid
     state: touch
-    mode: 0777
+    mode: "0777"
     owner: kibana
 
 # Starting Kibana
-
 - name: Starting Kibana
   service:
     name: kibana

--- a/ansible/roles/logstash/tasks/main.yml
+++ b/ansible/roles/logstash/tasks/main.yml
@@ -16,12 +16,11 @@
 # limitations under the License.
 #
 
+#
+# Installing Logstash
+#
 
- #
- # Installing Logstash
- #
-
- # Download Logstash
+# Download Logstash
 - name: "download logstash rpm"
   get_url:
   args:
@@ -30,7 +29,7 @@
     checksum: "{{ logstash_checksum }}"
     force: no
 
- # Install Logstash
+# Install Logstash
 - name: "ensure logstash is installed"
   become: true
   yum:
@@ -45,16 +44,16 @@
 - name: Update the startup.option file
   lineinfile:
     destfile: /etc/logstash/startup.options
-    regexp: 'LS_HOME=/usr/share/logstash'
-    line: 'LS_HOME=/etc/logstash'
+    regexp: "LS_HOME=/usr/share/logstash"
+    line: "LS_HOME=/etc/logstash"
   become: true
 
 # Update logstash config path locatione
 - name: Update logstash config path location
   lineinfile:
     destfile: /etc/logstash/logstash.yml
-    regexp: '# path.config:'
-    line: 'path.config: /etc/logstash/conf.d/'
+    regexp: "# path.config:"
+    line: "path.config: /etc/logstash/conf.d/"
   become: true
 
 # Make Logstash conf.d  directory
@@ -66,8 +65,8 @@
 
 - name: Copy logstash into conf.d folder
   template:
-     src: ../../logstash/templates/logstash-simple-2.conf
-     dest: /etc/logstash/conf.d/
+    src: ../../logstash/templates/logstash-simple-2.conf
+    dest: /etc/logstash/conf.d/
   become: true
 
 - name: Install beats input plugin

--- a/ansible/roles/proxy/tasks/main.yml
+++ b/ansible/roles/proxy/tasks/main.yml
@@ -16,7 +16,7 @@
 #
 
 - name: "add conf/keys to ~/.ssh/authorized_keys"
-  authorized_key: user={{ cluster_user }} key="{{ lookup('file', 'conf/keys') }}"
+  ansible.posix.authorized_key: user={{ cluster_user }} key="{{ lookup('file', 'conf/keys') }}"
   tags: configure_os
 - name: "ensure cluster user exists and generate ssh key"
   user: name={{ cluster_user }} generate_ssh_key=yes ssh_key_bits=4096 state=present
@@ -24,4 +24,4 @@
 - name: "create tarball directory on proxy"
   file: path={{ tarballs_dir }} state=directory
 - name: "copy /etc/hosts to proxy"
-  template: src=roles/proxy/templates/etc_hosts dest=/etc/etc_hosts owner=root group=root mode=0644
+  template: src=roles/proxy/templates/etc_hosts dest=/etc/etc_hosts owner=root group=root mode="0644"

--- a/ansible/spark.yml
+++ b/ansible/spark.yml
@@ -19,7 +19,7 @@
   tasks:
     - import_tasks: roles/spark/tasks/download.yml
       when: download_software
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   roles:
     - spark
 - hosts: spark

--- a/ansible/wipe-systemd.yml
+++ b/ansible/wipe-systemd.yml
@@ -18,64 +18,64 @@
   gather_facts: false
   become: yes
   tasks:
-  - name: "disable all accumulo systemd services on master"
-    systemd:
-      name: "{{ item }}"
-      state: stopped
-      enabled: no
-    with_items:
-      - "accumulo-master.service"
-      - "accumulo-monitor.service"
-      - "accumulo-gc.service"
-      - "accumulo-tracer.service"
-    register: stop_disable_service
-    failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
+    - name: "disable all accumulo systemd services on master"
+      systemd:
+        name: "{{ item }}"
+        state: stopped
+        enabled: no
+      with_items:
+        - "accumulo-master.service"
+        - "accumulo-monitor.service"
+        - "accumulo-gc.service"
+        - "accumulo-tracer.service"
+      register: stop_disable_service
+      failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
 
-  - name: "find accumulo systemd units to remove in masters"
-    find:
-      paths: /etc/systemd/system
-      patterns: 'accumulo-*.service'
-    register: find_accumulo_services
+    - name: "find accumulo systemd units to remove in masters"
+      find:
+        paths: /etc/systemd/system
+        patterns: "accumulo-*.service"
+      register: find_accumulo_services
 
-  - name: "remove accumulo systemd units in masters"
-    file: path="{{ item.path }}" state=absent
-    with_items:
-      - "{{ find_accumulo_services.files }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
+    - name: "remove accumulo systemd units in masters"
+      file: path="{{ item.path }}" state=absent
+      with_items:
+        - "{{ find_accumulo_services.files }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
 
 - hosts: workers
   gather_facts: false
   become: yes
   tasks:
-  - name: "disable accumulo tserver systemd services"
-    systemd:
-      name: "accumulo-tserver@{{ item }}.service"
-      state: stopped
-      enabled: no
-    with_sequence: "start=1 end={{ num_tservers }}"
-    register: stop_disable_service
-    failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
+    - name: "disable accumulo tserver systemd services"
+      systemd:
+        name: "accumulo-tserver@{{ item }}.service"
+        state: stopped
+        enabled: no
+      with_sequence: "start=1 end={{ num_tservers }}"
+      register: stop_disable_service
+      failed_when: "stop_disable_service is failed and 'Could not find the requested service' not in stop_disable_service.msg"
 
-  - name: "find accumulo tserver systemd units to remove in workers"
-    find:
-      paths: /etc/systemd/system
-      patterns: 'accumulo-*.service'
-    register: find_accumulo_tserver
+    - name: "find accumulo tserver systemd units to remove in workers"
+      find:
+        paths: /etc/systemd/system
+        patterns: "accumulo-*.service"
+      register: find_accumulo_tserver
 
-  - name: "remove accumulo tserver systemd units in workers"
-    file: path="{{ item.path }}" state=absent
-    with_items:
-      - "{{ find_accumulo_tserver.files }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
+    - name: "remove accumulo tserver systemd units in workers"
+      file: path="{{ item.path }}" state=absent
+      with_items:
+        - "{{ find_accumulo_tserver.files }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
 
-  - name: "reload config changes"
-    systemd: daemon_reload=yes
+    - name: "reload config changes"
+      systemd: daemon_reload=yes
 
-  - name: "reset failed on every node" # noqa 303
-    command: systemctl reset-failed
+    - name: "reset failed on every node" # noqa command-instead-of-module
+      command: systemctl reset-failed

--- a/ansible/wipe.yml
+++ b/ansible/wipe.yml
@@ -18,23 +18,23 @@
 - hosts: metrics
   become: yes
   tasks:
-  - name: "stop influxdb and grafana"
-    service: name={{ item }} state=stopped
-    with_items:
-      - influxdb
-      - grafana-server
-  - name: "wipe influxdb data"
-    file: path={{ default_data_dirs[0] }}/influxdb state=absent
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
-  - name: "wipe grafana db"
-    file: path=/var/lib/grafana/grafana.db state=absent
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
+    - name: "stop influxdb and grafana"
+      service: name={{ item }} state=stopped
+      with_items:
+        - influxdb
+        - grafana-server
+    - name: "wipe influxdb data"
+      file: path={{ default_data_dirs[0] }}/influxdb state=absent
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
+    - name: "wipe grafana db"
+      file: path=/var/lib/grafana/grafana.db state=absent
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
 
 - import_playbook: wipe-systemd.yml
   when: use_systemd
@@ -43,149 +43,150 @@
 
 - hosts: all
   tasks:
-  - name: "wipe software installation dirs"
-    file: path={{ item }} state=absent
-    with_items:
-      - "{{ hadoop_home }}"
-      - "{{ zookeeper_home }}"
-      - "{{ accumulo_home }}"
-      - "{{ fluo_home }}"
-      - "{{ spark_home }}"
-      - "{{ maven_home }}"
-      - "{{ hub_home }}"
-      - "{{ fluo_yarn_home }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
+    - name: "wipe software installation dirs"
+      file: path={{ item }} state=absent
+      with_items:
+        - "{{ hadoop_home }}"
+        - "{{ zookeeper_home }}"
+        - "{{ accumulo_home }}"
+        - "{{ fluo_home }}"
+        - "{{ spark_home }}"
+        - "{{ maven_home }}"
+        - "{{ hub_home }}"
+        - "{{ fluo_yarn_home }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
 
 - hosts: hadoop
   tasks:
-  - name: "wipe hadoop data"
-    file: path={{ item }}/hadoop state=absent
-    with_items: "{{ worker_data_dirs }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
-  - name: "remove logs folder"
-    file: path={{ item }}/logs state=absent
-    with_items: "{{ worker_data_dirs }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
+    - name: "wipe hadoop data"
+      file: path={{ item }}/hadoop state=absent
+      with_items: "{{ worker_data_dirs }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
+    - name: "remove logs folder"
+      file: path={{ item }}/logs state=absent
+      with_items: "{{ worker_data_dirs }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
 
 - hosts: zookeepers
   tasks:
-  - name: "wipe zookeeper data"
-    file: path={{ item }}/zookeeper state=absent
-    with_items: "{{ default_data_dirs }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
-  - name: "remove logs folder"
-    file: path={{ item }}/logs state=absent
-    with_items: "{{ default_data_dirs }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
+    - name: "wipe zookeeper data"
+      file: path={{ item }}/zookeeper state=absent
+      with_items: "{{ default_data_dirs }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
+    - name: "remove logs folder"
+      file: path={{ item }}/logs state=absent
+      with_items: "{{ default_data_dirs }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
 
 - hosts: accumulo
   tasks:
-  - name: "remove accumulo folder"
-    file: path={{ item }}/accumulo state=absent
-    with_items: "{{ worker_data_dirs }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
-  - name: "remove logs folder"
-    file: path={{ item }}/logs state=absent
-    with_items: "{{ worker_data_dirs }}"
-    register: delete_task
-    retries: 10
-    delay: 3
-    until: delete_task is success
+    - name: "remove accumulo folder"
+      file: path={{ item }}/accumulo state=absent
+      with_items: "{{ worker_data_dirs }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
+    - name: "remove logs folder"
+      file: path={{ item }}/logs state=absent
+      with_items: "{{ worker_data_dirs }}"
+      register: delete_task
+      retries: 10
+      delay: 3
+      until: delete_task is success
 
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   become: yes
   tasks:
-  - block:
-    - name: remove kibana
-      yum:
-        name: kibana*
-        state: absent
-    - name: delete kibana rpm
-      file:
-        path: /tmp/{{ kibana_rpm }}
-        state: absent
-        force: yes
-    - name: remove /etc/kibana directory
-      file:
-        path: /etc/kibana
-        state: absent
-        force: yes
-    - name: remove /var/log/kibana directory
-      file:
-        path: /var/log/kibana/
-        state: absent
-        force: yes
-    - name: remove /var/run/kibana directory
-      file:
-        path: /var/run/kibana/
-        state: absent
-        force: yes
-    - name: disable logstash beat
-      command: filebeat modules disable logstash
-      ignore_errors: yes
-    - name: remove filebeat
-      yum:
-        name: filebeat*
-        state: absent
-    - name: delete filebeat rpm
-      file:
-        path: /tmp/{{ filebeat_rpm }}
-        state: absent
-        force: yes
-    - name: delete /etc/filebeat directory
-      file:
-        path: /etc/filebeat/
-        state: absent
-        force: yes
-    - name: remove logstash
-      yum:
-        name: logstash*
-        state: absent
-    - name: delete logstash rpm
-      file:
-        path: /tmp/{{ logstash_rpm }}
-        state: absent
-        force: yes
-    - name: remove etc/logstash directory
-      file:
-        path: /etc/logstash
-        state: absent
-        force: yes
-    - name: remove elasticsearch
-      yum:
-        name: elasticsearch*
-        state: absent
-    - name: delete /etc/elasticsearch directory
-      file:
-        path: /etc/elasticsearch
-        state: absent
-        force: yes
-    - name: delete /var/lib/elasticsearch directory
-      file:
-        path: /var/lib/elasticsearch
-        state: absent
-        force: yes
-    - name: delete elasticsearch rpm
-      file:
-        path: /tmp/{{ elasticsearch_rpm }}
-        state: absent
-        force: yes
-    when: "'elkserver' in groups"
+    - name: "Tasks to remove ELK stack"
+      when: "'elkserver' in groups"
+      block:
+        - name: remove kibana
+          yum:
+            name: kibana*
+            state: absent
+        - name: delete kibana rpm
+          file:
+            path: /tmp/{{ kibana_rpm }}
+            state: absent
+            force: yes
+        - name: remove /etc/kibana directory
+          file:
+            path: /etc/kibana
+            state: absent
+            force: yes
+        - name: remove /var/log/kibana directory
+          file:
+            path: /var/log/kibana/
+            state: absent
+            force: yes
+        - name: remove /var/run/kibana directory
+          file:
+            path: /var/run/kibana/
+            state: absent
+            force: yes
+        - name: disable logstash beat # noqa ignore-errors
+          command: filebeat modules disable logstash
+          ignore_errors: yes
+        - name: remove filebeat
+          yum:
+            name: filebeat*
+            state: absent
+        - name: delete filebeat rpm
+          file:
+            path: /tmp/{{ filebeat_rpm }}
+            state: absent
+            force: yes
+        - name: delete /etc/filebeat directory
+          file:
+            path: /etc/filebeat/
+            state: absent
+            force: yes
+        - name: remove logstash
+          yum:
+            name: logstash*
+            state: absent
+        - name: delete logstash rpm
+          file:
+            path: /tmp/{{ logstash_rpm }}
+            state: absent
+            force: yes
+        - name: remove etc/logstash directory
+          file:
+            path: /etc/logstash
+            state: absent
+            force: yes
+        - name: remove elasticsearch
+          yum:
+            name: elasticsearch*
+            state: absent
+        - name: delete /etc/elasticsearch directory
+          file:
+            path: /etc/elasticsearch
+            state: absent
+            force: yes
+        - name: delete /var/lib/elasticsearch directory
+          file:
+            path: /var/lib/elasticsearch
+            state: absent
+            force: yes
+        - name: delete elasticsearch rpm
+          file:
+            path: /tmp/{{ elasticsearch_rpm }}
+            state: absent
+            force: yes

--- a/ansible/zookeeper.yml
+++ b/ansible/zookeeper.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-- hosts: all:!{{ azure_proxy_host }}
+- hosts: all:!{{ azure_proxy_host|default("") }}
   roles:
     - zookeeper
 - hosts: zookeepers

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,4 +1,4 @@
-flake8==4.0.1
-ansible-core==2.11.3
-ansible-lint==5.3.2
-nose2==0.10.0
+flake8==6.1.0
+ansible-core==2.15.5
+ansible-lint==6.21.1
+nose2==0.14.0

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -6,7 +6,7 @@ nose2 -v -B
 echo "SUCCESS: All nose2 tests completed."
 echo "Running Ansible-lint..."
 cd ..
-ansible-lint -x no-changed-when,risky-file-permissions,unnamed-task,var-naming
+ANSIBLE_LIBRARY=./ansible/library ansible-lint -x no-changed-when,risky-file-permissions,unnamed-task,var-naming,fqcn[action],fqcn[action-core],name[missing],name[casing],name[play],yaml[line-length],no-free-form,jinja[spacing],yaml[truthy]  ansible/ --exclude ansible/roles/azure/files/cloud-init.yml
 echo "SUCCESS: Ansible-lint completed."
 echo "Running flake8 to check Python code..."
 flake8

--- a/scripts/install-ansible-collections
+++ b/scripts/install-ansible-collections
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+ansible-galaxy collection install ansible.posix


### PR DESCRIPTION
The erstwhile `ansible-core` module was flagged as having a [vulnerability](https://github.com/apache/fluo-muchos/security/dependabot/1) which is fixed in ansible-core 2.15. After upgrading to that version of Ansible, unfortunately a bunch of other new ansible-lint warnings needed to be addressed. Hence this PR looks big, but the changes are largely stylistic. I will follow this PR up with another related PR specific to the Azure related ansible modules which also needed update, but this PR should resolve the Dependabot alert.