### PR TITLE
Address miscellaneous issues

### DIFF
--- a/ansible/conf/ansible.cfg
+++ b/ansible/conf/ansible.cfg
@@ -17,5 +17,5 @@
 host_key_checking = False
 forks = 50
 gathering = smart
-callback_whitelist = profile_tasks
+callbacks_enabled = profile_tasks
 timeout=30

--- a/ansible/roles/azure/tasks/create_adlsgen2.yml
+++ b/ansible/roles/azure/tasks/create_adlsgen2.yml
@@ -69,7 +69,7 @@
   set_fact:
     InstanceVolumes: "{{ InstanceVolumesManual if  instance_volumes_input.split('|')[0].split(',') ==  [''] else InstanceVolumesAuto }}"
 
-- name: Update instance_volumes_adls  in muchos.props
+- name: Update instance_volumes_adls in muchos.props
   lineinfile:
     path: "{{ deploy_path }}/conf/muchos.props"
     regexp: '^instance_volumes_adls\s*=\s*|^[#]instance_volumes_adls\s*=\s*'
@@ -77,21 +77,14 @@
 
 # Not registering variable because storage values are not visible immediately
 - name: Create ADLS Gen2 storage account using REST API
-  azure_rm_resource:
-    resource_group: "{{ resource_group }}"
-    provider: Storage
-    resource_type: storageAccounts
-    resource_name: "{{ item.split('@')[1].split('.')[0] }}"
-    api_version: "2019-04-01"
-    idempotency: yes
+  azure.azcollection.azure_rm_storageaccount:
     state: present
-    body:
-      sku:
-        name: "{{ adls_storage_type }}"
-      kind: StorageV2
-      properties:
-        isHnsEnabled: yes
-      location: "{{ location }}"
+    resource_group: "{{ resource_group }}"
+    name: "{{ item.split('@')[1].split('.')[0] }}"
+    type: "{{ adls_storage_type }}"
+    kind: "StorageV2"
+    is_hns_enabled: True
+    location: "{{ location }}"
   loop: "{{ InstanceVolumes }}"
 
 # Creating User Assigned identity with vmss_name suffixed by ua-msi if not specified in muchos.props

--- a/ansible/roles/common/tasks/azure.yml
+++ b/ansible/roles/common/tasks/azure.yml
@@ -24,6 +24,7 @@
   filesystem:
     fstype: xfs
     dev: "{{ item.path }}"
+    resizefs: yes
   with_items: "{{ files_matched.files }}"
 - name: Get UUID
   command: "blkid {{ item.path }} -s UUID -o value"

--- a/ansible/roles/common/templates/bash_profile
+++ b/ansible/roles/common/templates/bash_profile
@@ -7,8 +7,6 @@ fi
 
 # User specific environment and startup programs
 PATH=$JAVA_HOME/bin:$PATH
-PATH=$PATH:$HOME/.local/bin
-PATH=$PATH:$HOME/bin
 PATH=$PATH:{{ accumulo_home }}/bin
 PATH=$PATH:{{ fluo_home }}/bin
 PATH=$PATH:{{ fluo_yarn_home }}/bin

--- a/ansible/roles/common/templates/bashrc
+++ b/ansible/roles/common/templates/bashrc
@@ -5,6 +5,13 @@ if [ -f /etc/bashrc ]; then
   . /etc/bashrc
 fi
 
+# User specific environment
+if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
+then
+    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+fi
+export PATH
+
 export JAVA_HOME={{ java_home }}
 
 {% if hadoop_major_version == '2' %}


### PR DESCRIPTION
* Address an Ansible deprecation warning by changing the ansible.cfg file to use `callbacks_enabled`.
* Use native Ansible module to create ADLS Gen2 storage accounts.
* Resize filesystems to match provisioned disk space.
* Move user specific environment (PATH definition) to bashrc to ensure that SSH command invocation also leverages correct path definition.